### PR TITLE
Topic filter fix

### DIFF
--- a/modules/wri_search/config/install/facets.facet.all_event_topics.yml
+++ b/modules/wri_search/config/install/facets.facet.all_event_topics.yml
@@ -16,7 +16,7 @@ url_alias: topic
 weight: -2
 min_count: 0
 show_only_one_result: true
-field_identifier: term_parent_or_self_1
+field_identifier: smart_topic_parent
 facet_source_id: 'search_api:views_page__events__resources_page'
 widget:
   type: links

--- a/modules/wri_search/config/install/facets.facet.all_topics.yml
+++ b/modules/wri_search/config/install/facets.facet.all_topics.yml
@@ -16,7 +16,7 @@ url_alias: topic
 weight: -2
 min_count: 0
 show_only_one_result: true
-field_identifier: top_level_topic
+field_identifier: smart_topic_parent
 facet_source_id: 'search_api:views_page__resources__resources_page'
 widget:
   type: links

--- a/modules/wri_search/config/install/facets.facet.experts_all_topics.yml
+++ b/modules/wri_search/config/install/facets.facet.experts_all_topics.yml
@@ -16,7 +16,7 @@ url_alias: topic
 weight: -2
 min_count: 0
 show_only_one_result: true
-field_identifier: term_parent_or_self_1
+field_identifier: smart_topic_parent
 facet_source_id: 'search_api:views_page__experts_staff__experts_staff1'
 widget:
   type: links

--- a/modules/wri_search/config/install/search_api.index.sitewide.yml
+++ b/modules/wri_search/config/install/search_api.index.sitewide.yml
@@ -344,6 +344,14 @@ field_settings:
     dependencies:
       module:
         - node
+  smart_topic_parent:
+    label: 'Smart Topic'
+    datasource_id: 'entity:node'
+    property_path: smart_topic_parent
+    type: integer
+    dependencies:
+      module:
+        - wri_search
   status:
     label: Published
     datasource_id: 'entity:node'

--- a/modules/wri_search/src/Plugin/Field/FieldType/WriSmartTopic.php
+++ b/modules/wri_search/src/Plugin/Field/FieldType/WriSmartTopic.php
@@ -2,9 +2,8 @@
 
 namespace Drupal\wri_search\Plugin\Field\FieldType;
 
-
 /**
- * Variant of the topic field that includes all fields that could contain the topic.
+ * Topic field that includes all fields that could contain the topic.
  *
  * @FieldType(
  *   id = "smart_topic_parent",
@@ -27,19 +26,20 @@ class WriSmartTopic extends WriCalculatedField {
       $this->isCalculated = TRUE;
     }
   }
+
   /**
    * Compute the values.
    */
-  protected function computeValue(){
+  protected function computeValue() {
     // Add field_primary_topic.
     // Add field_topics
     // Add field_tags
-    // Add field_areas_of_expertise
+    // Add field_areas_of_expertise.
     $node = $this->getEntity();
     $field_primary_topics = $node->field_primary_topic ? $node->field_primary_topic->referencedEntities() : [];
-    $field_topics = $node->field_topics ? $node->field_topics->referencedEntities(): [];
-    $field_tags = $node->field_tags ? $node->field_tags->referencedEntities(): [];
-    $field_areas_of_expertise =  $node->field_areas_of_expertise ? $node->field_areas_of_expertise->referencedEntities() : [];
+    $field_topics = $node->field_topics ? $node->field_topics->referencedEntities() : [];
+    $field_tags = $node->field_tags ? $node->field_tags->referencedEntities() : [];
+    $field_areas_of_expertise = $node->field_areas_of_expertise ? $node->field_areas_of_expertise->referencedEntities() : [];
 
     $all_tags = $field_primary_topics + $field_topics + $field_tags + $field_areas_of_expertise;
     $index = 0;

--- a/modules/wri_search/src/Plugin/Field/FieldType/WriSmartTopic.php
+++ b/modules/wri_search/src/Plugin/Field/FieldType/WriSmartTopic.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\wri_search\Plugin\Field\FieldType;
+
+/**
+ * Variant of the 'text' field that calculates the related animal.
+ *
+ * @FieldType(
+ *   id = "smart_topic_parent",
+ *   label = @Translation("Smart Topic parent"),
+ *   description = @Translation("Any topic term attached to content, including its parent or itself."),
+ * )
+ */
+class WriSmartTopic extends WriCalculatedField {
+
+  /**
+   * Calculates the value of the field and sets it.
+   */
+  protected function ensureCalculated() {
+    if (!$this->isCalculated) {
+      $entity = $this->getEntity();
+      if (!$entity->isNew()) {
+        $parent = $this->getAllTopics();
+        $this->parent->setValue($parent);
+      }
+      $this->isCalculated = TRUE;
+    }
+  }
+
+  /**
+   * Returns the parent id, or the term id if no parent set.
+   */
+  private function getAllTopics() {
+    // Add field_primary_topic.
+    // Add field_topics
+    // Add field_tags
+    // Add field_areas_of_expertise
+    $entity = $this->getEntity();
+    if ($entity->parent->target_id == 0) {
+      $parent = $entity->id();
+    }
+    else {
+      $parent = $entity->parent->target_id;
+    }
+
+    return $parent;
+  }
+
+}

--- a/modules/wri_search/wri_search.install
+++ b/modules/wri_search/wri_search.install
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for search
+ */
+
+use Drupal\Core\Render\BubbleableMetadata;
+use Drupal\search_api\Plugin\views\query\SearchApiQuery;
+use Drupal\views\ViewExecutable;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function wri_search_update_8901() {
+  $search_index = \Drupal::configFactory()->getEditable('search_api.index.sitewide');
+  $smart_topic_parent = [
+    'label' => 'Smart Topic',
+    'datasource_id' => 'entity:node',
+    'property_path' => 'smart_topic_parent',
+    'type' => 'integer',
+    'dependencies' => [
+      'module' => ['wri_search']
+    ],
+  ];
+  $search_index->set('field_settings.smart_topic_parent', $smart_topic_parent);
+  $search_index->save(TRUE);
+
+  foreach(['facets.facet.experts_all_topics', 'facets.facet.all_event_topics', 'facets.facet.all_topics'] as $config_name) {
+    $experts = \Drupal::configFactory()->getEditable($config_name);
+    $experts->set('field_identifier', 'smart_topic_parent');
+    $experts->save(TRUE);
+  }
+}

--- a/modules/wri_search/wri_search.install
+++ b/modules/wri_search/wri_search.install
@@ -5,15 +5,8 @@
  * Update hooks for search
  */
 
-use Drupal\Core\Render\BubbleableMetadata;
-use Drupal\search_api\Plugin\views\query\SearchApiQuery;
-use Drupal\views\ViewExecutable;
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
-use Drupal\Core\Form\FormStateInterface;
-
 /**
- * Implements hook_entity_base_field_info().
+ * Adds the new Smart Topic index field and sets All Topic facets to use it.
  */
 function wri_search_update_8901() {
   $search_index = \Drupal::configFactory()->getEditable('search_api.index.sitewide');

--- a/modules/wri_search/wri_search.module
+++ b/modules/wri_search/wri_search.module
@@ -16,8 +16,8 @@ use Drupal\Core\Form\FormStateInterface;
  * Implements hook_entity_base_field_info().
  */
 function wri_search_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
   if ($entity_type->id() === 'taxonomy_term') {
-    $fields = [];
 
     // Add a field that shows the parent of the term, or itself if no parent.
     $fields['term_parent_or_self'] = BaseFieldDefinition::create('term_parent_or_self')
@@ -39,8 +39,19 @@ function wri_search_entity_base_field_info(EntityTypeInterface $entity_type) {
       ->setDisplayConfigurable('view', FALSE)
       ->setCardinality(-1);
 
-    return $fields;
   }
+    if ($entity_type->id() === "node") {
+      $fields['smart_topic_parent'] = BaseFieldDefinition::create('smart_topic_parent')
+        ->setName('smart_topic_parent')
+        ->setLabel(t('Smart Topic'))
+        ->setSetting('target_type', 'taxonomy_term')
+        ->setComputed(TRUE)
+        ->setClass('\Drupal\wri_search\WriCalculatedTexts')
+        ->setDisplayConfigurable('view', FALSE)
+        ->setCardinality(-1);
+    }
+
+    return $fields;
 }
 
 /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Jira ticket wri-1307 -- see https://docs.google.com/document/d/1hhnpdMrO5kOG0_p1h6YzuNVZIt7q9p_8BxyBy-SjC9k/edit#

The facets on the top of the resource library are only pulling in the "field_primary_topic" which means that when a user is filtering using the facet, they are missing a lot of content where that topic is added a secondary tag. 

You can see the difference here:Facet filter (leading topic business) here: https://www.wri.org/resources/topic/business-74/type/research-65

All things tagged business here: https://www.wri.org/resources/type/research-65/tags/business-74 

Facet settings are controlled here: wri.org/admin/config/search/facets .

Ideally we would only want Topics to show up on the top, but have everything tagged as that topic to show up in the results rather than just the leading topic.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Creates a new calculated field that contains all the fields that can reference a Topics and Subtopics term
- For all terms associated with a node that are Topics and Subtopics, index only the top-level term
- I'll write up testing instructions on the wriflagship PR (https://github.com/wri/wriflagship/pull/599)
- Adds an update hook to carry these settings to the existing sites.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Sites should re-index after running this update hook, as it adds a field.
