### PR TITLE
Issue WRIN#327 pulling in the content_translation code that depends o…

### DIFF
--- a/modules/wri_taxonomy/wri_taxonomy.module
+++ b/modules/wri_taxonomy/wri_taxonomy.module
@@ -16,12 +16,33 @@ use Drupal\Core\Url;
  * Implements hook_entity_type_alter().
  */
 function wri_taxonomy_entity_type_alter(array &$entity_types) {
+  $moduleHandler = \Drupal::service('module_handler');
   // Create a custom callback for the term uri.
   $entity_types['taxonomy_term']->setUriCallback('wri_taxonomy_term_uri');
   // Disable the default cononical link.
   $links = $entity_types['taxonomy_term']->get('links');
   unset($links['canonical']);
   $entity_types['taxonomy_term']->set('links', $links);
+
+  // This bit is necessary because the content_translation module requires
+  // there be a canonical link, which we just unset.
+  if ($moduleHandler->moduleExists('content_translation')) {
+    // Provide default route names for the translation paths.
+    $entity_type = $entity_types['taxonomy_term'];
+    if (!$entity_type->hasLinkTemplate('drupal:content-translation-overview')) {
+      $translations_path = '/taxonomy/term/{taxonomy_term}/translations';
+      $entity_type->setLinkTemplate('drupal:content-translation-overview', $translations_path);
+      $entity_type->setLinkTemplate('drupal:content-translation-add', $translations_path . '/add/{source}/{target}');
+      $entity_type->setLinkTemplate('drupal:content-translation-edit', $translations_path . '/edit/{language}');
+      $entity_type->setLinkTemplate('drupal:content-translation-delete', $translations_path . '/delete/{language}');
+    }
+    // @todo Remove this as soon as menu access checks rely on the
+    //   controller. See https://www.drupal.org/node/2155787.
+    $translation['content_translation'] = [
+      'access_callback' => 'content_translation_translate_access',
+    ];
+    $entity_types['taxonomy_term']->set('translation', $translation);
+  }
 }
 
 /**


### PR DESCRIPTION
…n a canonical url.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/wri/WRIN/issues/327

- If you try to set a taxonomy to be translatable, the form will submit without error, but the term will not be translatable.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- This updates the canonical url behavior to allow for translations. The translations module requires there to be a canonical url in order to add its additional translation links to an entity. This code copies that code [found here](https://git.drupalcode.org/project/drupal/-/blob/8.9.x/core/modules/content_translation/content_translation.module#L153) into our entity_alter function. This should only affect sites where the content_translation module is enabled.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
We should test this both on China and the Flagship. Flagship should see no change in behavior. China should see the ability to enable translations.

Multidevs set up for the flagship: https://github.com/wri/wriflagship/pull/626
And for China to test: https://github.com/wri/wri-china/pull/55