### PR TITLE
Arg issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -180,7 +180,7 @@
         "drupal/token_filter": "^1.2",
         "drupal/twig_tweak": "^2.6",
         "drupal/viewfield": "^3.0@beta",
-        "drupal/views_arg_order_sort": "1.x-dev",
+        "drupal/views_arg_order_sort": "^2.0@alpha",
         "drupal/views_autosubmit": "^1.3",
         "drupal/views_bulk_edit": "^2.4",
         "drupal/views_bulk_operations": "^3.9",

--- a/composer.json
+++ b/composer.json
@@ -180,7 +180,7 @@
         "drupal/token_filter": "^1.2",
         "drupal/twig_tweak": "^2.6",
         "drupal/viewfield": "^3.0@beta",
-        "drupal/views_arg_order_sort": "^2.0@alpha",
+        "drupal/views_arg_order_sort": "dev-1.x#5d13cfca5749294d127ebc06348827f775342b37",
         "drupal/views_autosubmit": "^1.3",
         "drupal/views_bulk_edit": "^2.4",
         "drupal/views_bulk_operations": "^3.9",

--- a/modules/wri_31block/config/install/views.view.3_1.yml
+++ b/modules/wri_31block/config/install/views.view.3_1.yml
@@ -173,6 +173,48 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_language_interface***': '***LANGUAGE_language_interface***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
       sorts:
         weight:
           id: weight


### PR DESCRIPTION
This is related to the SQL error seen on some views blocks on China. The ultimate issue is this one: https://www.drupal.org/project/views_arg_order_sort/issues/3212018

Related WRIN tickets:
https://github.com/wri/WRIN/issues/330
https://github.com/wri/WRIN/issues/329

That module used to  allow passing a NULL argument straight to the argument sort order. Now it seems to ignore the NULL argument, which leads to not passing in the content ids specified by that first argument, AND leading to the sql error:
<img width="1257" alt="Screen Shot 2021-11-17 at 10 36 19 AM" src="https://user-images.githubusercontent.com/999525/142262242-c8492a5a-a4dc-45b6-9f86-54fa8a822426.png">

This PR locks this module to the version that works. A future ticket should focus on fixing the issue on the module.

It also updates the config for the 3+1 view to take the current page's language into account.

China PR: https://github.com/wri/wri-china/pull/58