### PR TITLE
If you have workflow enabled on something other than a node, this cau…

### DIFF
--- a/modules/wri_admin/wri_admin.module
+++ b/modules/wri_admin/wri_admin.module
@@ -56,7 +56,7 @@ function wri_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) 
   }
   elseif ($form_id == 'content_moderation_entity_moderation_form') {
     $node = $form_state->get('entity');
-    if ($node) {
+    if ($node && $node instanceof Node) {
       $published_node = Node::load($node->id());
       $form['link_to_revision'] = [
         '#title' => t('Compare to published'),


### PR DESCRIPTION
…ses a WSOD.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

If you have the publishing workflow enabled for something other than a node, and you show the publishing workflow form, this was throwing a whitescreen.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Makes sure the `$node` variable is actually a node.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
