### PR TITLE
Locking search_api to a specific version until pantheon.yml can updat…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -166,6 +166,7 @@
         "drupal/s3fs": "^3.0@alpha",
         "drupal/scheduled_transitions": "^2.0",
         "drupal/schema_metatag": "^2.1",
+        "drupal/search_api": "1.20.0",
         "drupal/search_api_autocomplete": "^1.4",
         "drupal/search_api_exclude_entity": "^1.3",
         "drupal/search_api_pantheon": "1.0",


### PR DESCRIPTION
…e the database to 10.4.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
build tools was failing because the 1.21.0 version of search_api requires an index to be longer than what's allowed in the database version required for drupal 8. (It works fine with drupal 9)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Locks search_api to 1.21.0 for now

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
