### PR TITLE
Making sure to keep the main content without losing the text-formatte…

### DIFF
--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -1,3 +1,4 @@
+.main-content,
 .main-content .text-formatted,
 .cke_editable_themed,
 .paragraph--type--side-by-side .text-formatted {
@@ -71,11 +72,11 @@
     }
   }
 
-  ul > li {
+  & > ul li {
     margin-left: rem(32);
   }
 
-  ul > li::before {
+  & > ul li::before {
     background-color: $brand-gold;
     border-radius: 50%;
     display: block;


### PR DESCRIPTION
This is a less destructive fix for the ul/li work. Makes the bullets only show up if the ul is a direct child of either the main-content div, or a text-formatted div within the main-content div. Related PRs are:
https://github.com/wri/wri-china/pull/81
and
https://github.com/wri/wriflagship/pull/643

which both look good for vr tests now.