### PR TITLE
Menu woes

### DIFF
--- a/themes/custom/ts_wrin/sass/global/_header.scss
+++ b/themes/custom/ts_wrin/sass/global/_header.scss
@@ -437,7 +437,7 @@ header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
       outline: none;
     }
   }
-  & > li > .menu-item-title a {
+  & > li > a {
     @include font($caslon, "normal", "italic");
     @include font-line-height(15, 15);
     margin-right: $space-xs;

--- a/themes/custom/ts_wrin/sass/global/_header.scss
+++ b/themes/custom/ts_wrin/sass/global/_header.scss
@@ -437,7 +437,7 @@ header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
       outline: none;
     }
   }
-  & > li > a {
+  & > li > .menu-item-title a {
     @include font($caslon, "normal", "italic");
     @include font-line-height(15, 15);
     margin-right: $space-xs;

--- a/themes/custom/ts_wrin/sass/global/_header.scss
+++ b/themes/custom/ts_wrin/sass/global/_header.scss
@@ -145,7 +145,7 @@ header {
   }
   .tray-toggle.language-toggle svg {
     width: 28px;
-  }  
+  }
   .tray-toggle.filter-toggle {
     position: relative;
     border-radius: 5px;
@@ -280,7 +280,7 @@ header nav.menu--main {
   display: none;
 }
 
-header nav.menu--main.has-active-trail {
+header nav.menu--main.menu-item--expanded {
   bottom: 0;
   display: block;
   margin-left: 0;
@@ -362,7 +362,7 @@ header nav.menu--main .menu-wrapper > ul.menu {
   }
 }
 
-header nav.menu--main.has-active-trail .menu-wrapper {
+header nav.menu--main.menu-item--expanded .menu-wrapper {
   height: 37px;
   overflow: hidden;
   width: calc(100% - #{$grid-gutter-mobile});
@@ -372,7 +372,7 @@ header nav.menu--main.has-active-trail .menu-wrapper {
     width: calc(100% - #{$grid-gutter-mobile} * 3);
   }
 }
-header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
+header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
   box-sizing: border-box;
   margin-bottom: -10px;
   margin-top: 10px;
@@ -437,7 +437,7 @@ header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
       outline: none;
     }
   }
-  & > li > .menu-item-title a {
+  & > li > a {
     @include font($caslon, "normal", "italic");
     @include font-line-height(15, 15);
     margin-right: $space-xs;
@@ -453,7 +453,7 @@ header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
     display: none;
   }
 }
-.white nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
+.white nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
   &:after,
   li a {
     color: $white;
@@ -471,17 +471,17 @@ header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
   }
 }
 
-.white nav.menu--main.has-active-trail .back-arrow svg,
-.white nav.menu--main.has-active-trail .nav-arrow svg,
-.white nav.menu--main.has-active-trail .back-arrow svg path,
-.white nav.menu--main.has-active-trail .nav-arrow svg path {
+.white nav.menu--main.menu-item--expanded .back-arrow svg,
+.white nav.menu--main.menu-item--expanded .nav-arrow svg,
+.white nav.menu--main.menu-item--expanded .back-arrow svg path,
+.white nav.menu--main.menu-item--expanded .nav-arrow svg path {
   fill: $white;
   stroke: $white;
   outline: none;
   transition: all 0.2s linear;
 }
-.white nav.menu--main.has-active-trail .back-arrow,
-.white nav.menu--main.has-active-trail .nav-arrow {
+.white nav.menu--main.menu-item--expanded .back-arrow,
+.white nav.menu--main.menu-item--expanded .nav-arrow {
   @include hocus {
     outline: none;
     svg,
@@ -493,7 +493,7 @@ header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
   }
 }
 
-header nav.menu--main.has-active-trail.no-scroll {
+header nav.menu--main.menu-item--expanded.no-scroll {
   .menu-wrapper > ul.menu:after {
     content: none;
   }
@@ -667,11 +667,11 @@ header nav.menu--donate > ul.menu {
     nav.menu--main .menu-wrapper > ul.menu li.menu-item {
       align-items: flex-start;
     }
-    nav.menu--main.has-active-trail .menu-wrapper > ul:before,
+    nav.menu--main.menu-item--expanded .menu-wrapper > ul:before,
     nav.menu--main .menu-wrapper > ul:before {
       border-color: $black;
     }
-    nav.menu--main.has-active-trail
+    nav.menu--main.menu-item--expanded
       .menu-wrapper
       > ul:after
       nav.menu--main
@@ -706,11 +706,11 @@ header nav.menu--donate > ul.menu {
     .header-right .menu-toggle div span:after {
       background-color: $black;
     }
-    nav.menu--main.has-active-trail .menu-wrapper > ul.menu:after {
+    nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu:after {
       color: $black;
     }
-    nav.menu--main.has-active-trail .menu-wrapper > ul.menu li a,
-    nav.menu--main.has-active-trail .menu-wrapper > ul li a,
+    nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu li a,
+    nav.menu--main.menu-item--expanded .menu-wrapper > ul li a,
     nav.menu--main .menu-wrapper > ul li a,
     nav.menu--secondary > ul.menu li a {
       color: $black;
@@ -720,15 +720,15 @@ header nav.menu--donate > ul.menu {
         outline: none;
       }
     }
-    nav.menu--main.has-active-trail .back-arrow svg,
-    nav.menu--main.has-active-trail .nav-arrow svg,
-    nav.menu--main.has-active-trail .back-arrow svg path,
-    nav.menu--main.has-active-trail .nav-arrow svg path {
+    nav.menu--main.menu-item--expanded .back-arrow svg,
+    nav.menu--main.menu-item--expanded .nav-arrow svg,
+    nav.menu--main.menu-item--expanded .back-arrow svg path,
+    nav.menu--main.menu-item--expanded .nav-arrow svg path {
       fill: $black;
       stroke: $black;
     }
-    nav.menu--main.has-active-trail .back-arrow,
-    nav.menu--main.has-active-trail .nav-arrow {
+    nav.menu--main.menu-item--expanded .back-arrow,
+    nav.menu--main.menu-item--expanded .nav-arrow {
       @include hocus {
         outline: none;
         svg,

--- a/themes/custom/ts_wrin/sass/global/_header.scss
+++ b/themes/custom/ts_wrin/sass/global/_header.scss
@@ -280,7 +280,7 @@ header nav.menu--main {
   display: none;
 }
 
-header nav.menu--main.menu-item--expanded {
+header nav.menu--main.has-active-trail {
   bottom: 0;
   display: block;
   margin-left: 0;
@@ -362,7 +362,7 @@ header nav.menu--main .menu-wrapper > ul.menu {
   }
 }
 
-header nav.menu--main.menu-item--expanded .menu-wrapper {
+header nav.menu--main.has-active-trail .menu-wrapper {
   height: 37px;
   overflow: hidden;
   width: calc(100% - #{$grid-gutter-mobile});
@@ -372,7 +372,7 @@ header nav.menu--main.menu-item--expanded .menu-wrapper {
     width: calc(100% - #{$grid-gutter-mobile} * 3);
   }
 }
-header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
+header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
   box-sizing: border-box;
   margin-bottom: -10px;
   margin-top: 10px;
@@ -453,7 +453,7 @@ header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
     display: none;
   }
 }
-.white nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
+.white nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
   &:after,
   li a {
     color: $white;
@@ -471,17 +471,17 @@ header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
   }
 }
 
-.white nav.menu--main.menu-item--expanded .back-arrow svg,
-.white nav.menu--main.menu-item--expanded .nav-arrow svg,
-.white nav.menu--main.menu-item--expanded .back-arrow svg path,
-.white nav.menu--main.menu-item--expanded .nav-arrow svg path {
+.white nav.menu--main.has-active-trail .back-arrow svg,
+.white nav.menu--main.has-active-trail .nav-arrow svg,
+.white nav.menu--main.has-active-trail .back-arrow svg path,
+.white nav.menu--main.has-active-trail .nav-arrow svg path {
   fill: $white;
   stroke: $white;
   outline: none;
   transition: all 0.2s linear;
 }
-.white nav.menu--main.menu-item--expanded .back-arrow,
-.white nav.menu--main.menu-item--expanded .nav-arrow {
+.white nav.menu--main.has-active-trail .back-arrow,
+.white nav.menu--main.has-active-trail .nav-arrow {
   @include hocus {
     outline: none;
     svg,
@@ -493,7 +493,7 @@ header nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu {
   }
 }
 
-header nav.menu--main.menu-item--expanded.no-scroll {
+header nav.menu--main.has-active-trail.no-scroll {
   .menu-wrapper > ul.menu:after {
     content: none;
   }
@@ -667,11 +667,11 @@ header nav.menu--donate > ul.menu {
     nav.menu--main .menu-wrapper > ul.menu li.menu-item {
       align-items: flex-start;
     }
-    nav.menu--main.menu-item--expanded .menu-wrapper > ul:before,
+    nav.menu--main.has-active-trail .menu-wrapper > ul:before,
     nav.menu--main .menu-wrapper > ul:before {
       border-color: $black;
     }
-    nav.menu--main.menu-item--expanded
+    nav.menu--main.has-active-trail
       .menu-wrapper
       > ul:after
       nav.menu--main
@@ -706,11 +706,11 @@ header nav.menu--donate > ul.menu {
     .header-right .menu-toggle div span:after {
       background-color: $black;
     }
-    nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu:after {
+    nav.menu--main.has-active-trail .menu-wrapper > ul.menu:after {
       color: $black;
     }
-    nav.menu--main.menu-item--expanded .menu-wrapper > ul.menu li a,
-    nav.menu--main.menu-item--expanded .menu-wrapper > ul li a,
+    nav.menu--main.has-active-trail .menu-wrapper > ul.menu li a,
+    nav.menu--main.has-active-trail .menu-wrapper > ul li a,
     nav.menu--main .menu-wrapper > ul li a,
     nav.menu--secondary > ul.menu li a {
       color: $black;
@@ -720,15 +720,15 @@ header nav.menu--donate > ul.menu {
         outline: none;
       }
     }
-    nav.menu--main.menu-item--expanded .back-arrow svg,
-    nav.menu--main.menu-item--expanded .nav-arrow svg,
-    nav.menu--main.menu-item--expanded .back-arrow svg path,
-    nav.menu--main.menu-item--expanded .nav-arrow svg path {
+    nav.menu--main.has-active-trail .back-arrow svg,
+    nav.menu--main.has-active-trail .nav-arrow svg,
+    nav.menu--main.has-active-trail .back-arrow svg path,
+    nav.menu--main.has-active-trail .nav-arrow svg path {
       fill: $black;
       stroke: $black;
     }
-    nav.menu--main.menu-item--expanded .back-arrow,
-    nav.menu--main.menu-item--expanded .nav-arrow {
+    nav.menu--main.has-active-trail .back-arrow,
+    nav.menu--main.has-active-trail .nav-arrow {
       @include hocus {
         outline: none;
         svg,

--- a/themes/custom/ts_wrin/sass/global/_ts-hamburger-menu.scss
+++ b/themes/custom/ts_wrin/sass/global/_ts-hamburger-menu.scss
@@ -316,7 +316,7 @@ body.fixed {
         margin-top: 24px;
       }
     }
-    & > ul.menu > li > .menu-item-title {
+    & > ul.menu > li > .menu-item-title a {
       display: block;
       margin-bottom: 22px;
       position: relative;
@@ -326,6 +326,7 @@ body.fixed {
         center / cover;
       color: $brand-gold;
       content: "";
+      cursor: pointer;
       display: block;
       height: 14px;
       position: absolute;
@@ -404,12 +405,17 @@ body.fixed {
         display: block;
         margin-bottom: 22px;
       }
+
+      a {
+        display: block;
+      }
     }
     & > li > .menu-item-title:after {
       background: transparent url("../img/svgs/arrow-gold.svg") no-repeat center
         center / cover;
       color: $brand-gold;
       content: "";
+      cursor: pointer;
       display: block;
       height: 14px;
       position: absolute;

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -151,7 +151,7 @@ function ts_wrin_preprocess_block(array &$variables) {
   ];
   if ($variables['plugin_id'] == 'menu_block:main' && isset($variables["content"]["#items"])) {
     foreach ($variables["content"]["#items"] as $item) {
-      if ($item['in_active_trail'] && $item['is_expanded']) {
+      if ($item['in_active_trail']) {
         $variables['attributes']['class'][] = 'has-active-trail';
         break;
       }

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -151,7 +151,7 @@ function ts_wrin_preprocess_block(array &$variables) {
   ];
   if ($variables['plugin_id'] == 'menu_block:main' && isset($variables["content"]["#items"])) {
     foreach ($variables["content"]["#items"] as $item) {
-      if ($item['in_active_trail']) {
+      if ($item['in_active_trail'] && $item['is_expanded']) {
         $variables['attributes']['class'][] = 'has-active-trail';
         break;
       }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

(1) Italics missing in subnavigations: (i.e. https://dev-wriflagship.pantheonsite.io/research -- 'research' should be italicized, works on Live)
(2) Expanded menu: on hover the column titles (Our Work, Our Approach, etc) become underlined BUT only the text. On Live the underline extends across the column width. In mobile view, when you hover on the arrows next to "our work" "our approach" etc, it should turn into a hand pointer but currently is still an arrow pointer on Dev


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Changes the class that creates the secondary menus to be "menu-item--expanded" instead of "has-active-trail" so that menus without child elements will continue to load at the top level on IOs.
- Makes the link in in the hamburger menu into blocks so their hover states are consistent.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
WRI China PR: https://github.com/wri/wri-china/pull/85
WRI Flagship PR: https://github.com/wri/wriflagship/pull/646
