### PR TITLE
#323: add noindex, nofollow to project pages

### DIFF
--- a/modules/wri_seo/wri_seo.module
+++ b/modules/wri_seo/wri_seo.module
@@ -37,4 +37,27 @@ function wri_seo_page_attachments(array &$attachments) {
     }
   }
 
+  // Exclude certain paths from crawlers per WRIN issue #323.
+  $current_path = \Drupal::service('path.current')->getPath();
+
+  $noindex = [
+    '/project-resources/',
+    '/project-experts/',
+  ];
+
+  foreach ($noindex as $index) {
+    if (substr($current_path, 0, strlen($index)) === $index) {
+      $metatag = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'name' => 'robots',
+          'content' => 'noindex, nofollow',
+        ],
+      ];
+
+      $attachments['#attached']['html_head'][] = [$metatag, 'robots'];
+      break;
+    }
+  }
+
 }


### PR DESCRIPTION
Fix for https://github.com/wri/WRIN/issues/323

Multidev PR: https://github.com/wri/WRIN/issues/323

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the main branch (left side). 
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 323
- "Every project page has two associated pages: the experts page and the project resources page. These are throwing a lot of issues in our SEM audit as they all have the same title tags and meta-descriptions and they also have a funny url pattern --> aka not nested under the project they are associated with."


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds `<meta name="robots" content="noindex, nofollow">` to pages that have `/project-resources/` or `/project-experts/` in their paths. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
