### PR TITLE
#296: update hook to clear field definition errs

### DIFF
--- a/wri_sites.install
+++ b/wri_sites.install
@@ -112,7 +112,7 @@ function wri_sites_update_8904() {
  */
 function wri_sites_update_8905() {
   // If there's not already a block with revision_id 100482, create it.
-  $existing_block =  \Drupal::entityTypeManager()
+  $existing_block = \Drupal::entityTypeManager()
     ->getStorage('block_content')
     ->loadRevision(100482);
 
@@ -121,12 +121,11 @@ function wri_sites_update_8905() {
   }
 }
 
-
 /**
  * Updates the revisionid of the hero block, if it does not match.
  */
 function wri_sites_update_8906() {
-  $existing_block =  \Drupal::entityTypeManager()
+  $existing_block = \Drupal::entityTypeManager()
     ->getStorage('block_content')
     ->loadRevision(100070);
 
@@ -161,6 +160,27 @@ function wri_sites_update_8907() {
  */
 function wri_sites_update_8908() {
   \Drupal::service('module_installer')->install(['distro_helper']);
+}
+
+/**
+ * Clear cached entity definitions to remove reporting errors.
+ */
+function wri_sites_update_8909() {
+
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_type_manager->clearCachedDefinitions();
+
+  $entity_type_ids = [];
+  $change_summary = \Drupal::service('entity.definition_update_manager')->getChangeSummary();
+  foreach ($change_summary as $entity_type_id => $change_list) {
+    $entity_type = $entity_type_manager->getDefinition($entity_type_id);
+    \Drupal::entityDefinitionUpdateManager()->installEntityType($entity_type);
+    $entity_type_ids[] = $entity_type_id;
+  }
+
+  return t("Installed/Updated the entity type(s): @entity_type_ids", [
+    '@entity_type_ids' => implode(', ', $entity_type_ids),
+  ]);
 }
 
 /**
@@ -244,7 +264,7 @@ function _install_filedownload_blocks() {
     'field_cta_background' => 'has-blue-background-color',
     'langcode' => 'en',
     'reusable' => TRUE,
-    'uuid' => 'd21dee48-13ad-4782-abcd-68b8582a5c3e'
+    'uuid' => 'd21dee48-13ad-4782-abcd-68b8582a5c3e',
   ]);
   $block->save();
 }


### PR DESCRIPTION
https://github.com/wri/WRIN/issues/296

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
~~~
Mismatched entity and/or field definitions
The following changes were detected in the entity type and field definitions.
Custom block
The block_content.field_hero_type field needs to be updated.
Content
The node.field_toc field needs to be updated.
Paragraph
The paragraph.field_hero_image field needs to be updated.
The paragraph.field_hero_intro field needs to be updated.
The paragraph.field_hero_title field needs to be updated.
~~~

Issue Number: https://github.com/wri/WRIN/issues/296


## What is the new behavior?
- No errors! 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
