### PR TITLE
Issue #362 updating how the file gets called.

### DIFF
--- a/modules/wri_services_reader/src/Plugin/rest/resource/WriReaderRetrieveNodeResource.php
+++ b/modules/wri_services_reader/src/Plugin/rest/resource/WriReaderRetrieveNodeResource.php
@@ -159,7 +159,7 @@ class WriReaderRetrieveNodeResource extends ResourceBase {
             $media = Media::load($mid['target_id']);
             $fid = $media->field_media_file->target_id;
             $file = File::load($fid);
-            $files[]['url'] = $file->toUrl();
+            $files[]['url'] = \Drupal::service('file_url_generator')->generateAbsoluteString($file->getFileUri());
           }
           $node_array[$field_name] = [
             $language => $files,


### PR DESCRIPTION
## What issue(s) does this solve?
Fixes an error because files don't have a canonical url in Drupal, and the `url` method is deprecated in D9.

- [ ] Issue Number: https://github.com/wri/WRIN/issues/362

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updates the url call based on the advice here: https://drupal.stackexchange.com/a/308999

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/744
- [ ] China PR: N/A - they don't use this module.

<!-- add more environments to this section in the future -->