### PR TITLE
#357: let secondary footer menu items to flex-grow

### DIFF
--- a/themes/custom/ts_wrin/sass/global/_footer.scss
+++ b/themes/custom/ts_wrin/sass/global/_footer.scss
@@ -280,7 +280,7 @@
           justify-content: flex-start;
 
           & > li.menu-item {
-            flex: 0 1 calc(33% - 30px);
+            flex: 1 1 calc(33% - 30px);
             margin-right: 30px;
           }
         }


### PR DESCRIPTION
## What issue(s) does this solve?
- Secondary Footer does not flex to allow for fewer than three columns.

- [x] Issue Number: https://github.com/wri/WRIN/issues/357

## What is the new behavior?
- Secondary menu accommodates 1 - 3 columns gracefully. 

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->

- [ ] Flagship PR: 
- [x] China PR: https://pr-206-wri-china.pantheonsite.io/

<!-- add more environments to this section in the future -->