### PR TITLE
65 footer logo

### DIFF
--- a/themes/custom/ts_wrin/sass/global/_footer.scss
+++ b/themes/custom/ts_wrin/sass/global/_footer.scss
@@ -116,12 +116,14 @@
     }
 
     a {
-      background: url("../img/svgs/nav_logo_white.svg") no-repeat center center /
-        cover;
       display: inline-block;
       height: 50px;
       text-indent: -9999px;
-      width: 140px;
+      min-width: 140px;
+      width: auto;
+      img.logo-white {
+        max-width: 100%;
+      }
     }
   }
 

--- a/themes/custom/ts_wrin/sass/global/_footer.scss
+++ b/themes/custom/ts_wrin/sass/global/_footer.scss
@@ -72,12 +72,13 @@
 
 .region-footer .footer-padding {
   display: flex;
-  flex-wrap: wrap;
   padding-bottom: $padding-vertical;
   padding-top: $padding-vertical;
+  flex-wrap: wrap;
 
   @include mq($md) {
     flex-direction: column;
+    flex-wrap: nowrap;
   }
 
   @include mq($lg) {

--- a/themes/custom/ts_wrin/templates/layout/page.html.twig
+++ b/themes/custom/ts_wrin/templates/layout/page.html.twig
@@ -77,7 +77,7 @@
           <div class="footer-padding">
             <div class="footer-logo margin-bottom-md">
               <a href="/">
-                {{ 'Home'|t }}
+                <img class="logo-white" src="{{ footer_logo }}" alt="{{ 'Home'|t }}" />
               </a>
             </div>
             {% if page.footer_left %}

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -115,6 +115,11 @@ function ts_wrin_preprocess_page(array &$variables) {
   if ($status && ($status->getStatusCode() == 403 || $status->getStatusCode() == 404)) {
     $variables['is_node'] = TRUE;
   }
+
+  if (null != theme_get_setting('white_logo.path')) {
+    $logo_path = theme_get_setting('white_logo.path');
+    $variables['footer_logo'] = file_url_transform_relative(file_create_url($logo_path));
+  }
 }
 
 /**


### PR DESCRIPTION
## What issue(s) does this solve?
- Footer logo does not match site logo

- [ ] Issue Number: https://github.com/wri/wri_sites/issues/65
## What is the new behavior?
- Footer logo uses 'logo white' style

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/753
- [x] China PR: https://github.com/wri/wri-china/pull/208

<!-- add more environments to this section in the future -->