### PR TITLE
#69: remove capitalization on submenus

### DIFF
--- a/themes/custom/ts_wrin/sass/global/_header.scss
+++ b/themes/custom/ts_wrin/sass/global/_header.scss
@@ -438,7 +438,7 @@ header nav.menu--main.has-active-trail .menu-wrapper > ul.menu {
     @include font-line-height(14, 17);
     color: $black;
     letter-spacing: normal;
-    text-transform: capitalize;
+    text-transform: none;
     @include hocus {
       color: $med-grey;
       outline: none;


### PR DESCRIPTION
## What issue(s) does this solve?

- [x] Issue Number: https://github.com/wri/wri_sites/issues/69

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Header submenus no longer have text capitalized by default

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/754
- [ ] China PR: https://github.com/wri/wri-china/pull/209

<!-- add more environments to this section in the future -->