### PR TITLE
#373: set cache-control headers to 1 hour

### DIFF
--- a/modules/wri_admin/config/install/system.performance.yml
+++ b/modules/wri_admin/config/install/system.performance.yml
@@ -1,0 +1,15 @@
+cache:
+  page:
+    max_age: 3600
+css:
+  preprocess: true
+  gzip: true
+fast_404:
+  enabled: true
+  paths: '/\.(?:txt|png|gif|jpe?g|css|js|ico|swf|flv|cgi|bat|pl|dll|exe|asp)$/i'
+  exclude_paths: '/\/(?:styles|imagecache)\//'
+  html: '<!DOCTYPE html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1><p>The requested URL "@path" was not found on this server.</p></body></html>'
+js:
+  preprocess: true
+  gzip: true
+stale_file_threshold: 2592000

--- a/modules/wri_admin/wri_admin.install
+++ b/modules/wri_admin/wri_admin.install
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Install and update hooks for wri_admin.
+ */
+
+/**
+ * Extend the cache time to the Pantheon suggested time.
+ */
+function wri_admin_update_9301() {
+
+  // Add the new field configs.
+  \Drupal::service('distro_helper.updates')->installConfig('system.performance', 'wri_admin', 'install', 'TRUE');
+
+
+  $message = 'Set cache control headers to 1 hour';
+   return $message;
+}
+
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function wri_admin_update_dependencies() {
+  // We must have the distro_helper before we can run the 9301 update hook.
+  $dependencies['wri_admin'][9301] = [
+    'wri_sites' => 8908,
+  ];
+
+  return $dependencies;
+}


### PR DESCRIPTION
## What issue(s) does this solve?
Extend cache-control headers for better performance

- [ ] Issue Number: #WRIN/TODO

## What is the new behavior?
- CSS & JS cache control headers set to 1 hour

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->

- [ ] Flagship PR:
- [ ] China PR:

<!-- add more environments to this section in the future -->