### PR TITLE
Adds a link to config management best practices

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,7 @@
 ## Site-level pull requests for testing. Only merge when these PRs are approved:
 
 <!-- List any open pull requests where a reviewer might check code -->
+Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)
 
 - [ ] Flagship PR:
 - [ ] China PR:


### PR DESCRIPTION
@komejo I'm handing things off to Andy for a bit and we're trying to tighten up our documentation about PRs and release handling, so this addition adds a new link to the documentation on creating a site PR:
https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review

Basically, it's all the things you're already doing PLUS the step of pushing up `/config` changes on the IO level, if there are any.

So if a wri_sites PR has an update hook that changes config, the IO/flagship PR should also contain config changes.

This is different than what we've been doing, so I wanted to get your eyes on it to make sure it makes sense.

If it does, you can merge this!