### PR TITLE
Adds primary topic to dataLayer - #786

### DIFF
--- a/modules/wri_seo/js/wri_seo.js
+++ b/modules/wri_seo/js/wri_seo.js
@@ -5,6 +5,13 @@
  */
 (function ($, drupalSettings) {
 
+  // Get region values from current page
+  function getRegions() {
+    return $(".regions a").map(function () {
+      return $(this).text();
+    }).get().join(', ');
+  }
+
   let dataLayer = window.dataLayer = window.dataLayer || [];
   // Check variables before using them. The "!= null" checks for null or undefined.
   if (drupalSettings.wri_seo != null && drupalSettings.wri_seo.node_type != null) {
@@ -13,10 +20,7 @@
       case 'article':
         $(document).ready(function () {
           let articleSettings = drupalSettings.wri_seo.article_details
-          let regions = $(".regions a").map(function () {
-            return $(this).text();
-          }).get().join(', ');
-          articleSettings['insights region'] = regions;
+          articleSettings['insights region'] = getRegions();
           dataLayer.push(articleSettings);
         });
         break;
@@ -26,14 +30,13 @@
         // Regions are formatted at the field display level and as a result, not easy to
         // get from the backend.
         $(document).ready(function () {
-          let regions = $(".regions a").map(function () {
-            return $(this).text();
-          }).get().join(', ');
-          dataLayer.push({
-            "project topic": drupalSettings.wri_seo.project_details.topic ,
-            "project region": regions,
-          });
+          let projectSettings = drupalSettings.wri_seo.project_details;
+          projectSettings['project region'] = getRegions();
+          dataLayer.push(projectSettings);
         });
+        break;
+      default:
+        dataLayer.push(drupalSettings.wri_seo.default_details);
         break;
 
     }

--- a/modules/wri_seo/wri_seo.module
+++ b/modules/wri_seo/wri_seo.module
@@ -24,16 +24,26 @@ function wri_seo_page_attachments(array &$attachments) {
           'insights region' => '',
           'insights type' => $type ? $type->get('name')->getString() : '',
           'insights publish date' => date('Y-m-d', $node->getCreatedTime()),
+          'primary topic' => $topic ? $topic->get('name')->getString() : '',
         ];
         $attachments['#attached']['drupalSettings']['wri_seo']['article_details'] = $article_details;
         break;
 
       case 'project_detail':
         $project_details = [
-          'topic' => $topic ? $topic->get('name')->getString() : '',
+          'project topic' => $topic ? $topic->get('name')->getString() : '',
+          'primary topic' => $topic ? $topic->get('name')->getString() : '',
         ];
         $attachments['#attached']['drupalSettings']['wri_seo']['project_details'] = $project_details;
         break;
+
+      default:
+        $default_details = [
+          'primary topic' => $topic ? $topic->get('name')->getString() : '',
+        ];
+        $attachments['#attached']['drupalSettings']['wri_seo']['default_details'] = $default_details;
+        break;
+
     }
   }
 


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/wriflagship/issues/786

## What is the new behavior?
- Adds primary topic to the datalayer for all content types for access via GTM.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->

- [ ] Flagship PR:
- [ ] China PR:

<!-- add more environments to this section in the future -->