### PR TITLE
#371: add oembed_lazyload, configure media->video.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -165,6 +165,7 @@
         "drupal/menu_position": "^1.0@beta",
         "drupal/metatag": "^1.19",
         "drupal/metatag_google_scholar": "^1.0",
+        "drupal/oembed_lazyload": "^1.0@alpha",
         "drupal/onlyone": "^1.10",
         "drupal/paragraphs": "^1.12",
         "drupal/pathauto": "^1.9",

--- a/modules/wri_media/config/install/core.entity_view_display.media.video.default.yml
+++ b/modules/wri_media/config/install/core.entity_view_display.media.video.default.yml
@@ -6,20 +6,28 @@ dependencies:
     - field.field.media.video.field_tags
     - media.type.video
   module:
-    - media
+    - ds
+    - oembed_lazyload
 id: media.video.default
 targetEntityType: media
 bundle: video
 mode: default
 content:
   field_media_oembed_video:
-    type: oembed
+    type: lazyload_oembed
     label: hidden
-    weight: 0
     settings:
       max_width: 0
       max_height: 0
-    third_party_settings: {  }
+      strategy: intersection_observer
+      intersection_observer_margin: 100px
+    third_party_settings:
+      ds:
+        ft:
+          id: reset
+          settings:
+            lb: ''
+    weight: 0
     region: content
 hidden:
   created: true

--- a/modules/wri_media/wri_media.info.yml
+++ b/modules/wri_media/wri_media.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - media_library
   - blazy
   - focal_point
+  - oembed_lazyload
   - s3fs
   - wri_taxonomy
 theme:

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Install and update hooks for wri_media.
+ */
+
+/**
+ * Use the oembed_lazyload display mode for videos.
+ */
+function wri_media_update_9301() {
+
+  // Add the new field configs.
+  \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.video.default', 'wri_media', 'install', 'TRUE');
+
+
+  $message = 'Use the oembed_lazyload display mode for videos';
+   return $message;
+}
+
+
+/**
+ * Implements hook_update_dependencies().
+ */
+function wri_media_update_dependencies() {
+  // We must have the distro_helper before we can run the 9301 update hook.
+  $dependencies['wri_media'][9301] = [
+    'wri_sites' => 8908,
+  ];
+
+  return $dependencies;
+}

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -9,6 +9,7 @@
  * Use the oembed_lazyload display mode for videos.
  */
 function wri_media_update_9301() {
+  \Drupal::service('module_installer')->install(['oembed_lazyload']);
 
   // Add the new field configs.
   \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.video.default', 'wri_media', 'install', 'TRUE');


### PR DESCRIPTION
## What issue(s) does this solve?
Adds Lazy Loading to oembed media to improve performance

- [x] Issue Number: https://github.com/wri/WRIN/issues/371

## What is the new behavior?
- Embedded videos below the fold do not load (or call the large YouTube libraries) until they are close to the viewport. 

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/812
- [ ] China PR: https://github.com/wri/wri-china/pull/257

<!-- add more environments to this section in the future -->
