### PR TITLE
#83: make alt logo variable global, add to hnav

### DIFF
--- a/themes/custom/ts_wrin/templates/layout/region--hamburger-nav.html.twig
+++ b/themes/custom/ts_wrin/templates/layout/region--hamburger-nav.html.twig
@@ -24,7 +24,7 @@
 <div {{ regionId }}{{ attributes.addClass(classes) }}>
   <div class="hamburger-header">
     <a href="{{ path('<front>') }}" rel="home" class="site-logo">
-      <img class="logo-white" src="/profiles/contrib/wri_sites/themes/custom/ts_wrin/img/svgs/nav_logo_white.svg" alt="{{ 'Home'|t }}" />
+      <img class="logo-white" src="{{ footer_logo }}" alt="{{ 'Home'|t }}" />
     </a>
     <div class="donate-menu">{{ drupal_menu('donate') }}</div>
     <button class="mega_menu_close" aria-label="Toggle Mega Menu" title="Close Filter Menu">

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -12,6 +12,16 @@ use Drupal\Component\Utility\Html;
 use Drupal\wri_node\General;
 
 /**
+ * Implements hook_preprocess_region() *.html.twig.
+ */
+function ts_wrin_preprocess(array &$variables) {
+  if (null != theme_get_setting('white_logo.path')) {
+    $logo_path = theme_get_setting('white_logo.path');
+    $variables['footer_logo'] = \Drupal::service('file_url_generator')->transformRelative(file_create_url($logo_path));
+  }
+}
+
+/**
  * Implements hook_preprocess_HOOK() for html.html.twig.
  */
 function ts_wrin_preprocess_html(array &$variables) {
@@ -114,11 +124,6 @@ function ts_wrin_preprocess_page(array &$variables) {
   $status = \Drupal::requestStack()->getCurrentRequest()->attributes->get('exception');
   if ($status && ($status->getStatusCode() == 403 || $status->getStatusCode() == 404)) {
     $variables['is_node'] = TRUE;
-  }
-
-  if (null != theme_get_setting('white_logo.path')) {
-    $logo_path = theme_get_setting('white_logo.path');
-    $variables['footer_logo'] = \Drupal::service('file_url_generator')->transformRelative(file_create_url($logo_path));
   }
 }
 


### PR DESCRIPTION
## What issue(s) does this solve?
Logo in hamburger nav is hardcoded, it should use the alt (white) logo. 

- [ ] Issue Number: #83 

## What is the new behavior?
- hamburger nav logo should be the same as the footer logo.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:
- [ ] China PR:

<!-- add more environments to this section in the future -->
