### PR TITLE
Issue 89 resources

### DIFF
--- a/modules/wri_taxonomy/wri_taxonomy.module
+++ b/modules/wri_taxonomy/wri_taxonomy.module
@@ -99,8 +99,8 @@ function wri_taxonomy_term_uri(TermInterface $term) {
     if (isset($filter_by)) {
       $paths_helper = \Drupal::service('wri_search.pretty_facets_helper');
       if ($paths_helper) {
-        $path = Url::fromRoute('view.resources.resources_page');
-        return Url::fromUri('internal:/resources' . $paths_helper->getPrettyPaths($filter_by), ['language' => $term->language()]);
+        $internal_path = Url::fromRoute('view.resources.resources_page')->getInternalPath();
+        return Url::fromUri('internal:/' . $internal_path . $paths_helper->getPrettyPaths($filter_by), ['language' => $term->language()]);
       }
     }
   }

--- a/modules/wri_taxonomy/wri_taxonomy.module
+++ b/modules/wri_taxonomy/wri_taxonomy.module
@@ -99,6 +99,7 @@ function wri_taxonomy_term_uri(TermInterface $term) {
     if (isset($filter_by)) {
       $paths_helper = \Drupal::service('wri_search.pretty_facets_helper');
       if ($paths_helper) {
+        $path = Url::fromRoute('view.resources.resources_page');
         return Url::fromUri('internal:/resources' . $paths_helper->getPrettyPaths($filter_by), ['language' => $term->language()]);
       }
     }


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: #89 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Currently tags on the Brasil site link to `/resources` but that page is called `recursos` on that site. That url needs to be configurable based on the url of the view it points to.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/823
- [ ] China PR:
- [x] Brasil PR: https://github.com/wri/wri-brasil/pull/91

<!-- add more environments to this section in the future -->
