### PR TITLE
WIP: Adds custom responsive image field type, formatter, and widget - #61

### DIFF
--- a/modules/wri_media/src/Plugin/Field/FieldFormatter/CustomResponsiveImageFormatter.php
+++ b/modules/wri_media/src/Plugin/Field/FieldFormatter/CustomResponsiveImageFormatter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\wri_media\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\media\Entity\Media;
+
+/**
+ * Plugin implementation of the 'Custom Responsive Image Formatter' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "wri_media_custom_responsive_image_formatter",
+ *   label = @Translation("Custom Responsive Image Formatter"),
+ *   field_types = {
+ *     "wri_media_custom_responsive_image"
+ *   }
+ * )
+ */
+class CustomResponsiveImageFormatter extends FormatterBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $element = [];
+
+    $element['#theme'] = 'custom_responsive_image';
+
+    $values = $items->first()->getValue();
+    $default_media_id = $values['target_id_sm'];
+    $default_media = Media::load($default_media_id);
+
+    // Setup fallback image Large
+    $element['image'] = [
+      '#theme' => 'image',
+      '#uri' => $default_media->field_media_image->first()->entity->getFileUri(),
+    ];
+
+    //$element['#image'] = 'test';
+
+    return $element;
+  }
+
+}

--- a/modules/wri_media/src/Plugin/Field/FieldType/CustomResponsiveImageItem.php
+++ b/modules/wri_media/src/Plugin/Field/FieldType/CustomResponsiveImageItem.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\wri_media\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\TypedData\DataDefinition;
+
+/**
+ * Defines the 'wri_media_custom_responsive_image' field type.
+ *
+ * @FieldType(
+ *   id = "wri_media_custom_responsive_image",
+ *   label = @Translation("Custom Responsive Image"),
+ *   category = @Translation("General"),
+ *   default_widget = "wri_media_custom_responsive_image_widget",
+ *   default_formatter = "wri_media_custom_responsive_image_formatter"
+ * )
+ *
+ * @DCG
+ * If you are implementing a single value field type you may want to inherit
+ * this class form some of the field type classes provided by Drupal core.
+ * Check out /core/lib/Drupal/Core/Field/Plugin/Field/FieldType directory for a
+ * list of available field type implementations.
+ */
+class CustomResponsiveImageItem extends FieldItemBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
+    $properties = [];
+
+    $properties['target_id_sm'] = DataDefinition::create('integer')
+      ->setLabel(t('Small'))
+      ->setDescription(t('Small Image'));
+    $properties['target_id_md'] = DataDefinition::create('integer')
+      ->setLabel(t('Medium'))
+      ->setDescription(t('Medium Image'));
+    $properties['target_id_lg'] = DataDefinition::create('integer')
+      ->setLabel(t('Large'))
+      ->setDescription(t('Large Image'));
+    $properties['target_id_xl'] = DataDefinition::create('integer')
+      ->setLabel(t('XL'))
+      ->setDescription(t('XL Image'));
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function schema(FieldStorageDefinitionInterface $field_definition) {
+    return [
+      'columns' => [
+        'target_id_sm' => [
+          'description' => 'The ID of the Small file entity.',
+          'type' => 'int',
+          'unsigned' => TRUE,
+        ],
+        'target_id_md' => [
+          'description' => 'The ID of the Medium file entity.',
+          'type' => 'int',
+          'unsigned' => TRUE,
+        ],
+        'target_id_lg' => [
+          'description' => 'The ID of the Large file entity.',
+          'type' => 'int',
+          'unsigned' => TRUE,
+        ],
+        'target_id_xl' => [
+          'description' => 'The ID of the X-large file entity.',
+          'type' => 'int',
+          'unsigned' => TRUE,
+        ],
+      ],
+    ];
+  }
+}

--- a/modules/wri_media/src/Plugin/Field/FieldWidget/CustomResponsiveImageWidget.php
+++ b/modules/wri_media/src/Plugin/Field/FieldWidget/CustomResponsiveImageWidget.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\wri_media\Plugin\Field\FieldWidget;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\WidgetBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Defines the 'wri_media_custom_responsive_image_widget' field widget.
+ *
+ * @FieldWidget(
+ *   id = "wri_media_custom_responsive_image_widget",
+ *   label = @Translation("Custom Responsive Image Widget"),
+ *   field_types = {
+ *     "wri_media_custom_responsive_image"
+ *   }
+ * )
+ */
+class CustomResponsiveImageWidget extends WidgetBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
+    $item = $items[$delta];
+
+    $element['target_id_sm'] = [
+      '#type' => 'media_library',
+      '#allowed_bundles' => ['image'],
+      '#title' => $this->t('Image for Small breakpoint'),
+      '#default_value' => $item->target_id_sm ?? NULL,
+      '#limit' => 1,
+      '#weight' => '0',
+    ];
+
+    $element['target_id_md'] = [
+      '#type' => 'media_library',
+      '#title' => $this->t('Image for Medium breakpoint'),
+      '#allowed_bundles' => ['image'],
+      '#weight' => '0',
+      '#limit' => 1,
+      '#default_value' => $item->target_id_md ?? NULL,
+    ];
+
+    $element['target_id_lg'] = [
+      '#type' => 'media_library',
+      '#title' => $this->t('Image for Large breakpoint'),
+      '#allowed_bundles' => ['image'],
+      '#default_value' => $item->target_id_lg ?? NULL,
+      '#weight' => '0',
+      '#limit' => 1,
+    ];
+
+    $element['target_id_xl'] = [
+      '#type' => 'media_library',
+      '#title' => $this->t('Image for XL breakpoint'),
+      '#allowed_bundles' => ['image'],
+      '#default_value' => $item->target_id_xl ?? NULL,
+      '#weight' => '0',
+      '#limit' => 1,
+    ];
+
+    return $element;
+  }
+
+}

--- a/modules/wri_media/templates/custom-responsive-image.html.twig
+++ b/modules/wri_media/templates/custom-responsive-image.html.twig
@@ -1,0 +1,11 @@
+{# @TODO wip, needs work. #}
+<picture>
+  {% if sources %}
+    {% for source_attributes in sources %}
+      <source{{ source_attributes }}/>
+    {% endfor %}
+  {% endif %}
+
+  {# The controlling image, with the fallback image in srcset. #}
+  {{ image }}
+</picture>

--- a/modules/wri_media/wri_media.module
+++ b/modules/wri_media/wri_media.module
@@ -20,6 +20,16 @@ function wri_media_theme() {
   $items['details__media'] = [
     'base hook' => 'details',
   ];
+  $items['media__responsive_visualization'] = [
+    'base hook' => 'media'
+  ];
+  $items['custom_responsive_image'] = [
+    'variables' => [
+      'image' => NULL,
+      'sources' => [],
+    ],
+    'render element' => 'children',
+  ];
   return $items;
 }
 
@@ -69,6 +79,31 @@ function wri_media_preprocess_media(&$variables) {
     // If both the thumbnail and the embed code are set to show, hide the
     // thumbnail.
     $variables["content"]["thumbnail"]['#access'] = FALSE;
+  }
+
+  // Preprocess responsive visualizations.
+  if ($variables['elements']['#media']->bundle() === 'responsive_visualization') {
+
+    // Setup fallback image Large
+    $variables['content']['img_element'] = [
+      '#theme' => 'image',
+      '#uri' => $variables["elements"]["#media"]->field_media_image->first()->entity->getFileUri(),
+    ];
+
+    // Build an array of all available images.
+    // Process each item
+    //   - Get image dimensions (
+    //     $image = \Drupal::service('image.factory')->get($variables['uri']);
+    //    $width = $image->getWidth();
+    //    $height = $image->getHeight();)
+    //   - build up the srcset attribute
+
+    $test = '';
+    $variables['content']['visualization'] = '<p>It works!</p>';
+    // Transform large image to url.
+    $file_url_generator = \Drupal::service('file_url_generator');
+
+
   }
 }
 


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: #61 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds custom field type, widget and formatted

## To do
- [ ] Finish template work so that field renders proper `<picture>` element with srcset items from the field values
- [ ] Add any styles or theming required

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:
- [ ] China PR:

<!-- add more environments to this section in the future -->
