### PR TITLE
#768: microsite subpage tweak, page templates.

### DIFF
--- a/modules/wri_subpage/wri_subpage.module
+++ b/modules/wri_subpage/wri_subpage.module
@@ -23,30 +23,30 @@ function wri_subpage_node_update(EntityInterface $entity) {
   if (isset($entity->field_parent_page)) {
     $parent = $entity->field_parent_page->entity;
     if ($parent) {
+      // Set the correct menu for microsites vs all others.
+      'microsite' == $parent->bundle() ? $menu_name = 'microsites' : $menu_name = 'page-hierarchies';
       $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
 
-      // Save the parent at the root of the Page Heirarchy menu, if not already
-      // there.
-      $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], 'page-hierarchies'));
+      // Save the parent at the root of the menu, if not already there.
+      $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], $menu_name));
       if (!$parent_link_menu_id) {
         $parent_link_menu = MenuLinkContent::create([
           'title' => $parent->label(),
           'link' => ['uri' => 'entity:node/' . $parent->id()],
-          'menu_name' => 'page-hierarchies',
+          'menu_name' => $menu_name,
           'expanded' => TRUE,
         ]);
         $parent_link_menu->save();
         $parent_link_menu_id = $parent_link_menu->getPluginId();
       }
 
-      // Save the current page as a child of the parent in the Page Hierarchy
-      // menu.
-      $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], 'page-hierarchies');
+      // Save the current page as a child of the parent in the appropriate menu.
+      $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
       if (!$current_link_menu_menu) {
         $current_link_menu = MenuLinkContent::create([
           'title' => $entity->label(),
           'link' => ['uri' => 'entity:node/' . $entity->id()],
-          'menu_name' => 'page-hierarchies',
+          'menu_name' => $menu_name,
           'parent' => $parent_link_menu_id,
           'expanded' => TRUE,
         ]);

--- a/themes/custom/ts_wrin/templates/layout/page--microsite.html.twig
+++ b/themes/custom/ts_wrin/templates/layout/page--microsite.html.twig
@@ -1,0 +1,72 @@
+{{ drupal_block('local_tasks_block') }}
+{% if page.wrin_custom.wrinfilterstatus %}
+  {% include 'wrin-filter-status' %}
+{% endif %}
+<div id="tray-nav-wrapper">
+  <div id="tray-nav-canvas">
+    <header>
+      <div class="container header-wrapper">
+        <div class="header-right {{ menu_color }}">
+
+          {% if page.wrin_custom.languageswitcher %}
+            {% include 'wrin-language-button' %}
+          {% endif %}
+
+        </div>
+      </div>
+    </header>
+
+    <div class="mobile-menu-target">
+      <div class="ts-mobile-menu__wrapper">
+
+      </div>
+    </div>
+
+    {% if page.admin %}
+      {{ page.admin }}
+    {% endif %}
+
+    {% if page.content %}
+      {% if is_node %}
+        {{page.content}}
+      {% else %}
+      <div class="landing-page__content container margin-top-md margin-bottom-md">
+        <div class="content__inner">
+          {{ drupal_block('local_tasks_block') }}
+          {{page.content}}
+        </div>
+      </div>
+      {% endif %}
+    {% endif %}
+
+{#     {% if page.footer_top %}
+      {{page.footer_top}}
+    {% endif %} #}
+
+    {% if page.footer_left or page.footer_right %}
+      <div class="region-footer">
+        <div class="container">
+          <div class="footer-padding">
+            <div class="footer-logo margin-bottom-md">
+              <a href="/">
+                <img class="logo-white" src="{{ footer_logo }}" alt="{{ 'Home'|t }}" />
+              </a>
+            </div>
+            {% if page.footer_left %}
+              {{page.footer_left}}
+            {% endif %}
+
+            {% if page.footer_right %}
+              {{page.footer_right}}
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if page.modals %}
+      {{ page.modals }}
+    {% endif %}
+
+  </div>
+</div>

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -131,7 +131,16 @@ function ts_wrin_preprocess_page(array &$variables) {
  * Implements hook_theme_suggestions_page_alter().
  */
 function ts_wrin_theme_suggestions_page_alter(array &$suggestions, array $variables) {
-
+  // Allow page-level template suggestions.
+  if ($node = \Drupal::routeMatch()->getParameter('node')) {
+    $suggestions[] = 'page__' . $node->bundle();
+  }
+  if (isset($node->field_parent_page)) {
+    $parent = $node->field_parent_page->entity;
+    if ('microsite' == $parent->bundle()) {
+     $suggestions[] = 'page__microsite';
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/wri/wriflagship/issues/768

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Updates .theme to allow for a custom page template for the 'Microsite' content type.
- Adds a stripped-down `page--microsite.html.twig` template for the above.
- Ensures subpages of microsites inherit the `page--microsite.html.twig`.
- Adds parent & child microsite pages to the microsites menu.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/882
- [ ] China PR: n/a (for now at least)

<!-- add more environments to this section in the future -->
