### PR TITLE
Simplifies the full view modes of data and program centers, which are…

### DIFF
--- a/modules/wri_data/config/install/core.entity_view_display.node.data.full.yml
+++ b/modules/wri_data/config/install/core.entity_view_display.node.data.full.yml
@@ -26,24 +26,20 @@ dependencies:
     - node.type.data
   module:
     - ctools
-    - element_class_formatter
-    - field_group
     - layout_builder
     - layout_builder_restrictions
     - layout_discovery
-    - taxonomy
-    - text
     - user
-    - wri_block
 third_party_settings:
   layout_builder:
-    allow_custom: true
     enabled: true
+    allow_custom: true
     sections:
       -
         layout_id: layout_onecol
         layout_settings:
           label: ''
+          context_mapping: {  }
         components:
           9533b12c-7cef-4495-ae2f-445d3f4efd9d:
             uuid: 9533b12c-7cef-4495-ae2f-445d3f4efd9d
@@ -51,70 +47,70 @@ third_party_settings:
             configuration:
               id: 'field_block:node:data:field_primary_contacts'
               label: 'Primary contacts'
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: above
-                type: entity_reference_entity_view
-                settings:
-                  view_mode: teaser
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: entity_reference_entity_view
+                label: above
+                settings:
+                  view_mode: teaser
+                third_party_settings: {  }
             weight: -7
+            additional: {  }
           00f1ffd1-da77-4d4b-9cc3-d1487d936958:
             uuid: 00f1ffd1-da77-4d4b-9cc3-d1487d936958
             region: content
             configuration:
               id: 'field_block:node:data:field_projects'
               label: 'Projects that Include this Data Set'
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: above
-                type: entity_reference_entity_view
-                settings:
-                  view_mode: card
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: entity_reference_entity_view
+                label: above
+                settings:
+                  view_mode: card
+                third_party_settings: {  }
             weight: -8
+            additional: {  }
           3e34bc2c-8a93-47b9-9743-407f22f313c4:
             uuid: 3e34bc2c-8a93-47b9-9743-407f22f313c4
             region: content
             configuration:
               id: 'field_block:node:data:field_related_resources'
               label: 'Related to this Resource'
-              provider: layout_builder
               label_display: visible
-              formatter:
-                label: hidden
-                type: related_field_formatter
-                settings:
-                  view_mode: teaser
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: related_field_formatter
+                label: hidden
+                settings:
+                  view_mode: teaser
+                third_party_settings: {  }
             weight: -9
+            additional: {  }
           896827be-fa61-4dbd-a2b5-9d3152d11ff0:
             uuid: 896827be-fa61-4dbd-a2b5-9d3152d11ff0
             region: content
             configuration:
               id: 'entity_view:node'
               label: 'Entity view (Content)'
-              provider: ctools
               label_display: '0'
+              provider: ctools
               view_mode: main_content
               context_mapping:
                 entity: layout_builder.entity
-            additional: {  }
             weight: -10
+            additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories:
@@ -132,9 +128,13 @@ third_party_settings:
       - System
       - User
       - 'WRI block'
+      - Webform
       - core
     entity_view_mode_restriction:
-      whitelisted_blocks:
+      allowed_layouts:
+        - layout_onecol
+      denylisted_blocks: {  }
+      allowlisted_blocks:
         'Chaos Tools':
           - 'entity_view:node'
         Components: {  }
@@ -151,124 +151,28 @@ third_party_settings:
         User: {  }
         'WRI block': {  }
         core: {  }
-      blacklisted_blocks: {  }
-      allowed_layouts:
-        - layout_onecol
-  field_group:
-    group_image:
-      children: {  }
-      parent_name: ''
-      weight: 20
-      format_type: details_sidebar
-      region: hidden
-      format_settings:
-        id: ''
-        classes: ''
-        description: ''
-        open: false
-        weight: 0
-        required_fields: false
-      label: Image
+      restricted_categories:
+        - Devel
+        - 'WRI Data Viz'
+        - 'WRI External Publications'
+        - Webform
 id: node.data.full
 targetEntityType: node
 bundle: data
 mode: full
 content:
-  body:
-    label: hidden
-    type: text_default
-    weight: 8
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    region: content
-  content_moderation_control:
     weight: -20
     region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_featured_project:
-    weight: 109
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_intro:
-    weight: 1
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-    type: text_default
-    region: hero_image
-  field_primary_contacts:
-    weight: 108
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_primary_topic:
-    type: entity_reference_rss_category
-    weight: 4
-    region: content
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-  field_projects:
-    label: above
-    type: entity_reference_entity_view
-    settings:
-      view_mode: card
-      link: false
-    third_party_settings: {  }
-    weight: 110
-    region: content
-  field_region:
-    type: entity_reference_rss_category
-    weight: 5
-    region: content
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-  field_related_resources:
-    label: hidden
-    type: related_field_formatter
-    settings:
-      view_mode: teaser
-      link: false
-    third_party_settings: {  }
-    weight: 111
-    region: content
-  field_twitter_account:
-    weight: 102
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
-  field_type:
-    type: entity_reference_label_class
-    weight: 2
-    region: hero_text
-    label: hidden
-    settings:
-      class: ''
-      link: true
-      tag: ''
-    third_party_settings: {  }
   links:
+    settings: {  }
+    third_party_settings: {  }
     weight: 100
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
+  body: true
   changed: true
   default_langcode: true
   field_authors: true
@@ -278,6 +182,7 @@ hidden:
   field_featured_headline: true
   field_featured_text: true
   field_files: true
+  field_intro: true
   field_isbn: true
   field_lead_in: true
   field_license: true
@@ -286,9 +191,15 @@ hidden:
   field_metatags: true
   field_narrative_taxonomy: true
   field_platform_link: true
+  field_primary_contacts: true
+  field_primary_topic: true
+  field_projects: true
+  field_region: true
+  field_related_resources: true
   field_statistics: true
   field_tags: true
   field_total_pages: true
+  field_type: true
   langcode: true
   layout_builder__layout: true
   nid: true

--- a/modules/wri_program/config/install/core.entity_view_display.node.program_center.full.yml
+++ b/modules/wri_program/config/install/core.entity_view_display.node.program_center.full.yml
@@ -16,29 +16,27 @@ dependencies:
     - field.field.node.program_center.field_narrative_taxonomy
     - field.field.node.program_center.field_primary_contacts
     - field.field.node.program_center.field_primary_topic
+    - field.field.node.program_center.field_show_more_link
     - field.field.node.program_center.field_twitter_account
     - field.field.node.program_center.field_type
     - field.field.node.program_center.layout_builder__layout
     - node.type.program_center
   module:
-    - field_group
     - layout_builder
     - layout_builder_restrictions
     - layout_discovery
-    - link
-    - media
-    - text
     - user
     - wri_node
 third_party_settings:
   layout_builder:
-    allow_custom: true
     enabled: true
+    allow_custom: true
     sections:
       -
         layout_id: layout_onecol
         layout_settings:
           label: Hero
+          context_mapping: {  }
         components:
           7ed8cbf8-c802-44e4-9e4b-3a7d8ad314e7:
             uuid: 7ed8cbf8-c802-44e4-9e4b-3a7d8ad314e7
@@ -46,42 +44,43 @@ third_party_settings:
             configuration:
               id: 'field_block:node:program_center:field_twitter_account'
               label: 'Follow on Twitter'
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: hidden
-                type: link_ally_class
-                settings:
-                  link_text: 'Follow on Twitter'
-                  screenreader_text: ''
-                  tag: ''
-                  class: ''
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: link_ally_class
+                label: hidden
+                settings:
+                  class: ''
+                  link_text: 'Follow on Twitter'
+                  screenreader_text: ''
+                  tag: ''
+                third_party_settings: {  }
             weight: 1
+            additional: {  }
           28457f99-400e-4a9a-aa78-31177fe5c60e:
             uuid: 28457f99-400e-4a9a-aa78-31177fe5c60e
             region: content
             configuration:
               id: 'inline_block:hero'
               label: Hero
-              provider: layout_builder
               label_display: '0'
+              provider: layout_builder
               view_mode: full
+              context_mapping: {  }
               block_revision_id: 100070
               block_serialized: null
-              context_mapping: {  }
-            additional: {  }
             weight: 0
+            additional: {  }
         third_party_settings: {  }
       -
         layout_id: 'single_file_component_layout:wri_page_main_content'
         layout_settings:
-          component_context: {  }
           label: 'Main page content'
+          context_mapping: {  }
+          component_context: {  }
         components:
           5f4ab45b-2d34-4893-9a61-c3d29573d93e:
             uuid: 5f4ab45b-2d34-4893-9a61-c3d29573d93e
@@ -89,42 +88,43 @@ third_party_settings:
             configuration:
               id: 'field_block:node:program_center:body'
               label: Body
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: hidden
-                type: text_default
-                settings: {  }
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: text_default
+                label: hidden
+                settings: {  }
+                third_party_settings: {  }
             weight: 6
+            additional: {  }
           325aa2f4-b6fb-4448-98df-8b2b0f505402:
             uuid: 325aa2f4-b6fb-4448-98df-8b2b0f505402
             region: content
             configuration:
               id: 'field_block:node:program_center:field_intro_paragraphs'
               label: 'Intro Paragraphs'
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: hidden
-                type: entity_reference_revisions_entity_view
-                settings:
-                  view_mode: default
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: entity_reference_revisions_entity_view
+                label: hidden
+                settings:
+                  view_mode: default
+                third_party_settings: {  }
             weight: 5
+            additional: {  }
         third_party_settings: {  }
       -
         layout_id: layout_onecol
         layout_settings:
           label: 'Continued Blocks'
+          context_mapping: {  }
           component_context: {  }
         components:
           f2bb374a-3ea9-4168-b5b9-e596636700fd:
@@ -133,52 +133,52 @@ third_party_settings:
             configuration:
               id: 'field_block:node:program_center:field_featured_experts'
               label: 'Featured Experts'
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: above
-                type: entity_reference_entity_view
-                settings:
-                  view_mode: teaser
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: entity_reference_entity_view
+                label: above
+                settings:
+                  view_mode: teaser
+                third_party_settings: {  }
             weight: -9
+            additional: {  }
           f1699151-e710-4123-b8c5-6d27274ffc97:
             uuid: f1699151-e710-4123-b8c5-6d27274ffc97
             region: content
             configuration:
               id: 'field_block:node:program_center:field_primary_contacts'
               label: 'Media Contacts'
-              provider: layout_builder
               label_display: '0'
-              formatter:
-                label: above
-                type: entity_reference_entity_view
-                settings:
-                  view_mode: teaser
-                third_party_settings: {  }
+              provider: layout_builder
               context_mapping:
                 entity: layout_builder.entity
                 view_mode: view_mode
-            additional: {  }
+              formatter:
+                type: entity_reference_entity_view
+                label: above
+                settings:
+                  view_mode: teaser
+                third_party_settings: {  }
             weight: -8
+            additional: {  }
           8a4e6af5-aef1-4629-a702-a390e87327b9:
             uuid: 8a4e6af5-aef1-4629-a702-a390e87327b9
             region: content
             configuration:
               id: 'inline_block:narrative_taxonomy'
               label: 'Narrative Taxonomy'
-              provider: layout_builder
               label_display: ''
+              provider: layout_builder
               view_mode: default
+              context_mapping: {  }
               block_revision_id: 100482
               block_serialized: null
-              context_mapping: {  }
-            additional: {  }
             weight: -10
+            additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories:
@@ -199,7 +199,11 @@ third_party_settings:
       - 'WRI block'
       - core
     entity_view_mode_restriction:
-      whitelisted_blocks:
+      allowed_layouts:
+        - layout_onecol
+        - 'single_file_component_layout:wri_page_main_content'
+      denylisted_blocks: {  }
+      allowlisted_blocks:
         'Chaos Tools':
           - 'entity_view:node'
         Components: {  }
@@ -220,107 +224,37 @@ third_party_settings:
         User: {  }
         'WRI block': {  }
         core: {  }
-      blacklisted_blocks: {  }
-      allowed_layouts:
-        - layout_onecol
-        - 'single_file_component_layout:wri_page_main_content'
-  field_group:
-    group_image:
-      children: {  }
-      parent_name: ''
-      weight: 20
-      format_type: details_sidebar
-      region: hidden
-      format_settings:
-        id: ''
-        classes: ''
-        description: ''
-        open: false
-        weight: 0
-        required_fields: false
-      label: Image
 id: node.program_center.full
 targetEntityType: node
 bundle: program_center
 mode: full
 content:
-  body:
-    label: hidden
-    type: text_default
-    weight: 2
+  content_moderation_control:
     settings: {  }
     third_party_settings: {  }
-    region: content
-  content_moderation_control:
     weight: -20
     region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_featured_experts:
-    weight: 107
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_featured_project:
-    weight: 109
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_intro:
-    type: text_default
-    weight: 1
-    region: content
-    label: hidden
-    settings: {  }
-    third_party_settings: {  }
-  field_main_image:
-    type: media_thumbnail
-    weight: 0
-    region: content
-    label: hidden
-    settings:
-      image_style: ''
-      image_link: ''
-    third_party_settings: {  }
-  field_primary_contacts:
-    weight: 108
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_twitter_account:
-    weight: 102
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    type: link
-    region: content
   links:
+    settings: {  }
+    third_party_settings: {  }
     weight: 100
     region: content
-    settings: {  }
-    third_party_settings: {  }
 hidden:
+  body: true
+  field_featured_experts: true
+  field_featured_project: true
+  field_intro: true
   field_intro_paragraphs: true
   field_lead_in: true
   field_long_title: true
+  field_main_image: true
   field_metatag: true
   field_narrative_taxonomy: true
+  field_primary_contacts: true
   field_primary_topic: true
+  field_show_more_link: true
   field_statistics: true
+  field_twitter_account: true
   field_type: true
   langcode: true
   layout_builder__layout: true


### PR DESCRIPTION
… controlled via layout builder.

## What issue(s) does this solve?
While upgrading modules, I noticed that a few entity views are using the field_group module in theory -- but in practice the config is leftover from before we turned on layout builder. Removing all the fields that are not shown anyway, and simplifying the install config. this should have no effect on the frontend.

- [ ] Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [x] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.) - we're not bothering to update.

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:
- [ ] China PR:
- [ ] Brasil PR:
- [ ] Indonesia PR:

<!-- add more environments to this section in the future -->
