### PR TITLE
Issue 932

### DIFF
--- a/modules/wri_article/config/install/core.entity_view_display.node.article.full.yml
+++ b/modules/wri_article/config/install/core.entity_view_display.node.article.full.yml
@@ -66,17 +66,12 @@ third_party_settings:
             uuid: 1318f40a-3bb2-4fd1-a9a2-bdb7dfc8734f
             region: content
             configuration:
-              id: 'related_resources_fallback'
+              id: related_resources_fallback
               label: 'Relevant Work'
-              provider: wri_block
               label_display: visible
-              formatter:
-                label: hidden
-                type: related_field_formatter
-                settings:
-                  view_mode: teaser
-                third_party_settings: {  }
-              context_mapping: { }
+              provider: wri_block
+              context_mapping: {  }
+            weight: -3
             additional: {  }
             weight: -5
         third_party_settings: {  }

--- a/modules/wri_article/config/install/core.entity_view_display.node.article.full.yml
+++ b/modules/wri_article/config/install/core.entity_view_display.node.article.full.yml
@@ -71,7 +71,6 @@ third_party_settings:
               label_display: visible
               provider: wri_block
               context_mapping: {  }
-            weight: -3
             additional: {  }
             weight: -5
         third_party_settings: {  }

--- a/modules/wri_block/src/Plugin/Block/RelatedResourcesFallback.php
+++ b/modules/wri_block/src/Plugin/Block/RelatedResourcesFallback.php
@@ -86,7 +86,10 @@ class RelatedResourcesFallback extends BlockBase implements ContainerFactoryPlug
       else {
         $build['#title'] = '';
       }
-      return $build;
+      if (isset($build[0]) || isset($build["#rows"][0]["#rows"][0])) {
+        // Only build blocks with stuff in them.
+        return $build;
+      }
     }
     return [];
   }

--- a/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
+++ b/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
@@ -13,67 +13,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @FieldFormatter(
  *   id = "related_field_formatter",
- *   label = @Translation("Related field formatter"),
+ *   label = @Translation("Deprecated Related Field Formatter"),
  *   field_types = {
  *     "entity_reference"
  *   }
  * )
  */
-class RelatedFieldFormatter extends EntityReferenceEntityFormatter {
-
-  /**
-   * Request stack.
-   *
-   * @var \Symfony\Component\HttpFoundation\RequestStack
-   */
-  protected $requestStack;
-
-  /**
-   * {@inheritDoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
-    $instance->requestStack = $container->get('request_stack');
-    return $instance;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function defaultSettings() {
-    return [
-      // Implement default settings.
-    ] + parent::defaultSettings();
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-    return [
-      // Implement settings form.
-    ] + parent::settingsForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function viewElements(FieldItemListInterface $items, $langcode) {
-    if (isset($items) && $items->count()) {
-      return parent::viewElements($items, $langcode);
-    }
-    else {
-      $node = $this->requestStack->getCurrentRequest()->attributes->get('node');
-      if ($node) {
-        $view = Views::getView('related_content');
-        $view->setDisplay('block_1');
-        $view->setArguments([$node->id()]);
-        $build = $view->render();
-        $build['#field_name'] = $items->getName();
-        return $build;
-      }
-    }
-    return [];
-  }
-
-}
+class RelatedFieldFormatter extends EntityReferenceEntityFormatter { }

--- a/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
+++ b/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
@@ -13,10 +13,67 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @FieldFormatter(
  *   id = "related_field_formatter",
- *   label = @Translation("Deprecated Related Field Formatter"),
+ *   label = @Translation("Related field formatter"),
  *   field_types = {
  *     "entity_reference"
  *   }
  * )
  */
-class RelatedFieldFormatter extends EntityReferenceEntityFormatter { }
+class RelatedFieldFormatter extends EntityReferenceEntityFormatter {
+
+  /**
+   * Request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+    $instance->requestStack = $container->get('request_stack');
+    return $instance;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      // Implement default settings.
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    return [
+      // Implement settings form.
+    ] + parent::settingsForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    if (isset($items) && $items->count()) {
+      return parent::viewElements($items, $langcode);
+    }
+    else {
+      $node = $this->requestStack->getCurrentRequest()->attributes->get('node');
+      if ($node) {
+        $view = Views::getView('related_content');
+        $view->setDisplay('block_1');
+        $view->setArguments([$node->id()]);
+        $build = $view->render();
+        $build['#field_name'] = $items->getName();
+        return $build;
+      }
+    }
+    return [];
+  }
+
+}

--- a/modules/wri_event/config/install/core.entity_view_display.node.event.full.yml
+++ b/modules/wri_event/config/install/core.entity_view_display.node.event.full.yml
@@ -47,17 +47,6 @@ third_party_settings:
         layout_settings:
           label: ''
         components:
-          1b1b039f-13a9-4b80-bc51-ddce8d62c0a2:
-            uuid: 1b1b039f-13a9-4b80-bc51-ddce8d62c0a2
-            region: content
-            configuration:
-              id: related_resources_fallback
-              label: 'Related to this Event'
-              label_display: visible
-              provider: wri_block
-              context_mapping: {  }
-            weight: -9
-            additional: {  }
           440300b2-4b41-4061-9a83-96c5fd87f8a0:
             uuid: 440300b2-4b41-4061-9a83-96c5fd87f8a0
             region: content
@@ -130,12 +119,31 @@ third_party_settings:
             uuid: 4afeb9ae-b988-4507-92d3-521af213474a
             region: content
             configuration:
+              id: 'extra_field_block:node:event:content_moderation_control'
               label_display: '0'
               context_mapping:
                 entity: layout_builder.entity
-              id: 'extra_field_block:node:event:content_moderation_control'
-            additional: {  }
             weight: -4
+            additional: {  }
+          fa953d7a-54c8-4b9e-9d26-2fc96dc923be:
+            uuid: fa953d7a-54c8-4b9e-9d26-2fc96dc923be
+            region: content
+            configuration:
+              id: 'field_block:node:event:field_related_resources'
+              label: 'Related to this Event'
+              label_display: visible
+              provider: layout_builder
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+              formatter:
+                type: entity_reference_entity_view
+                label: hidden
+                settings:
+                  view_mode: teaser
+                third_party_settings: {  }
+            weight: -9
+            additional: {  }
         third_party_settings: {  }
   layout_builder_restrictions:
     allowed_block_categories: {  }
@@ -150,6 +158,7 @@ third_party_settings:
         'Content fields':
           - 'field_block:node:event:field_primary_contacts'
           - 'field_block:node:event:field_related_events'
+          - 'field_block:node:event:field_related_resources'
         Devel: {  }
         Facets: {  }
         'Facets summary (Experimental)': {  }


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [x] Issue Number: https://github.com/wri/wriflagship/issues/932

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Reworks the Related Content display to hide blocks that are empty of both views and entity references
- Updates the Event full display that comes with the profile to not use the fallback block
- Updates a reference to the Article full display that contained some code leftovers.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
