### PR TITLE
Issue 932 cache

### DIFF
--- a/modules/wri_block/src/Plugin/Block/RelatedResourcesFallback.php
+++ b/modules/wri_block/src/Plugin/Block/RelatedResourcesFallback.php
@@ -91,7 +91,7 @@ class RelatedResourcesFallback extends BlockBase implements ContainerFactoryPlug
         return $build;
       }
     }
-    return [];
+    return ['#cache' => ['max-age' => 60]];
   }
 
 }

--- a/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
+++ b/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
@@ -70,6 +70,9 @@ class RelatedFieldFormatter extends EntityReferenceEntityFormatter {
         $view->setArguments([$node->id()]);
         $build = $view->render();
         $build['#field_name'] = $items->getName();
+        if(empty($view->result)) {
+          $build['#cache']['max-age'] = 60;
+        }
         return $build;
       }
     }

--- a/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
+++ b/modules/wri_block/src/Plugin/Field/FieldFormatter/RelatedFieldFormatter.php
@@ -70,9 +70,6 @@ class RelatedFieldFormatter extends EntityReferenceEntityFormatter {
         $view->setArguments([$node->id()]);
         $build = $view->render();
         $build['#field_name'] = $items->getName();
-        if(empty($view->result)) {
-          $build['#cache']['max-age'] = 60;
-        }
         return $build;
       }
     }


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/wriflagship/issues/932

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a 60 second cache to the block rendering if it's empty. Prevents a cached empty block from showing forever.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Brasil: This is already on live.
