### PR TITLE
Issue #1030 a check that the item is published before it's part of th…

### DIFF
--- a/modules/wri_common/wri_common.module
+++ b/modules/wri_common/wri_common.module
@@ -206,13 +206,13 @@ function wri_common_get_node_topics(Node $node, $secondary_only = FALSE) {
   $topics = [];
   if (!$secondary_only && $node->hasField('field_primary_topic') && ($topic_items = $node->get('field_primary_topic')) && !$topic_items->isEmpty()) {
     $topic_item = $topic_items->first()->entity;
-    if ($topic_item) {
+    if ($topic_item && $topic_item->isPublished()) {
       $topics[] = $topic_item;
     }
   }
   if ($node->hasField('field_tags') && ($tag_items = $node->get('field_tags')) && !$tag_items->isEmpty()) {
     foreach ($tag_items as $tag_item) {
-      if (isset($tag_item->entity) && $tag_item->entity->bundle() == 'topics_and_subtopics') {
+      if (isset($tag_item->entity) && $tag_item->entity->bundle() == 'topics_and_subtopics' && $tag_item->entity->isPublished()) {
         $topics[] = $tag_item->entity;
       }
     }


### PR DESCRIPTION
…e narrative taxonomy.

## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [x] Issue Number: https://github.com/wri/wriflagship/issues/1030

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a isPublished check to the custom token that creates the narrative taxonomy terms topics and subtopics.
-
-

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/1031

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
