### PR TITLE
Issue #398 adding all the blazy properties to all images.

### DIFF
--- a/themes/custom/ts_wrin/sass/components/_homepage.scss
+++ b/themes/custom/ts_wrin/sass/components/_homepage.scss
@@ -26,7 +26,6 @@
     }
   }
   .field--name-field-hero-image {
-    width: auto;
     @include column-width(1, 5);
 
     @include mq($ph) {
@@ -169,19 +168,13 @@
   img {
     height: 660px;
     min-width: 100%;
+    width: auto;
     @include mq($md) {
       height: 640px;
     }
     @include mq($lg) {
       height: 900px;
     }
-  }
-}
-// Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1694741
-@-moz-document url-prefix() {
-  .field--name-field-hero-image img {
-    height: auto;
-    width: auto;
   }
 }
 

--- a/themes/custom/ts_wrin/sass/components/_homepage.scss
+++ b/themes/custom/ts_wrin/sass/components/_homepage.scss
@@ -26,6 +26,7 @@
     }
   }
   .field--name-field-hero-image {
+    width: auto;
     @include column-width(1, 5);
 
     @include mq($ph) {

--- a/themes/custom/ts_wrin/sass/components/_person.scss
+++ b/themes/custom/ts_wrin/sass/components/_person.scss
@@ -250,6 +250,7 @@
     padding: 0 10px 0 20px;
     img {
       border-radius: 50%;
+      width: 100px;
     }
   }
   .leadership {

--- a/themes/custom/ts_wrin/sass/components/_person.scss
+++ b/themes/custom/ts_wrin/sass/components/_person.scss
@@ -214,6 +214,7 @@
   img {
     border-radius: 50%;
     object-fit: cover;
+    width: 100px;
   }
 
   .person-teaser__inner-wrapper {

--- a/themes/custom/ts_wrin/sass/components/_publication-detail.scss
+++ b/themes/custom/ts_wrin/sass/components/_publication-detail.scss
@@ -52,6 +52,10 @@
       @include mq($lg) {
         @include column-width(9, $grid-columns);
       }
+
+      img {
+        width: auto;
+      }
     }
 
     .buttons {

--- a/themes/custom/ts_wrin/sass/components/_search-results.scss
+++ b/themes/custom/ts_wrin/sass/components/_search-results.scss
@@ -139,6 +139,7 @@
     display: none;
     max-width: 200px;
     margin: 0 auto;
+    width: auto;
     @include mq($md) {
       display: block;
     }

--- a/themes/custom/ts_wrin/sass/config/_04.base.scss
+++ b/themes/custom/ts_wrin/sass/config/_04.base.scss
@@ -85,6 +85,9 @@ p a {
 
 img {
   display: block;
+  height: auto;
+  min-height: 1px;
+  width: 100%;
 }
 
 /**


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/WRIN/issues/398

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adding back image settings that were needed when blazy existed to fix XLarge screens.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1041