### PR TITLE
Issue #212 a command to clean up internal authors and can run first.

### DIFF
--- a/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
+++ b/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
@@ -7,7 +7,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\wri_author\Entity\WRIAuthor;
 use Drush\Commands\DrushCommands;
 
-
 /**
  * Drush commands for cleaning up wri_author references.
  */
@@ -205,7 +204,7 @@ class WriAuthorCustomCommands extends DrushCommands {
   }
 
   /**
-   * Drush command to make any internal authors with invalid references external.
+   * Makes any internal authors with invalid references external via Drush.
    *
    * @command wri_author:bad-internal-to-external
    * @usage wri_author:bad-internal-to-external

--- a/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
+++ b/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
@@ -49,10 +49,13 @@ class WriAuthorCustomCommands extends DrushCommands {
     // Find any authors that have the same name, within bundle.
     // SELECT name FROM wri_author_field_data GROUP BY name HAVING count(name)>1
     $query = $this->entityTypeManager->getStorage('wri_author')->getAggregateQuery();
-    $author_list = $query->groupBy('name')
-      ->groupBy('field_person')
-      ->groupBy('field_person_link')
-      ->condition('type', $type)
+    $query->groupBy('name');
+    if ($type == 'internal') {
+      $query->groupBy('field_person');
+    } else {
+      $query->groupBy('field_person_link');
+    }
+    $author_list = $query->condition('type', $type)
       ->conditionAggregate('name', 'COUNT', '1', '>')
       ->range(0, $number)
       ->execute();

--- a/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
+++ b/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
@@ -194,7 +194,7 @@ class WriAuthorCustomCommands extends DrushCommands {
           echo "Node Updated: " . $node_id . "\n";
         }
       }
-      // Delete duplicate authors.
+      // Delete duplicate author.
       $excess_author = WRIAuthor::load($author_id);
       if ($author_id !== $primary_author_id) {
         echo "Duplicate Deleted: " . $author_id . "\n\n";

--- a/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
+++ b/modules/wri_author/src/Commands/WriAuthorCustomCommands.php
@@ -52,7 +52,8 @@ class WriAuthorCustomCommands extends DrushCommands {
     $query->groupBy('name');
     if ($type == 'internal') {
       $query->groupBy('field_person');
-    } else {
+    }
+    else {
       $query->groupBy('field_person_link');
     }
     $author_list = $query->condition('type', $type)

--- a/modules/wri_author/wri_author.module
+++ b/modules/wri_author/wri_author.module
@@ -77,7 +77,7 @@ function wri_author_node_delete(EntityInterface $node) {
         $new_external_author = WRIAuthor::create([
           'type' => 'external',
           'field_person_link' => [
-            'title' => str_replace(' (WRI)', '', $author->label()),
+            'title' => $author->label(),
             'uri' => 'route:<nolink>',
           ],
           'id' => $author->id(),


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/WRIN/issues/212

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a new drush command to clean up internal authors that may be pointing to deleted author nodes.
- Also removes a reference to (WRI) which I took out once we could use the advanced  autocomplete to distinguish between internal and external authors.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1072

