### PR TITLE
#809 Added default image on taxonomy

### DIFF
--- a/modules/wri_node/wri_node.module
+++ b/modules/wri_node/wri_node.module
@@ -10,6 +10,8 @@ use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
 use Drupal\wri_node\General;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\file\Entity\File;
 
 /**
  * Implements hook_preprocess_hook().
@@ -60,18 +62,34 @@ function wri_node_preprocess_wri_page_hero(&$context) {
 function wri_node_preprocess_layout__card(&$variables) {
   $variables['default_image'] = [];
   if (Drupal::config('wri_node.settings')->get('use_fallback_image')) {
-    if (isset($variables["content"]['tag']["field_primary_topic"][0]["#title"])) {
-      $image_url = \Drupal::service('extension.list.module')
-        ->getPath('wri_node') . '/images/' . strtolower(str_replace(' ', '-', $variables["content"]['tag']["field_primary_topic"][0]["#title"])) . '.jpg';
-      if (!file_exists($image_url)) {
-        $image_url = \Drupal::service('extension.list.module')
-          ->getPath('wri_node') . '/images/default.jpg';
+    $node = $variables['content']['#node'];
+    $topic = $node->field_primary_topic->target_id;
+    $image_url = '';
+    if ($topic) {
+      // Get default image form term.
+      $term = Term::load($topic);
+      if ($term) {
+        if ($term->field_default_image->target_id) {
+          $image_url = $term->field_default_image->entity->getFileUri();
+        }
+        else {
+          // Get default image from default by name.
+          $name = $term->name->value;
+          $image_url = \Drupal::service('extension.list.module')
+              ->getPath('wri_node') . '/images/' . strtolower(str_replace(' ', '-', $name)) . '.jpg';
+          if (!file_exists($image_url)) {
+            $image_url = \Drupal::service('extension.list.module')
+                ->getPath('wri_node') . '/images/default.jpg';
+          }
+        }
       }
     }
     else {
+      // Get default image.
       $image_url = \Drupal::service('extension.list.module')
-        ->getPath('wri_node') . '/images/default.jpg';
+          ->getPath('wri_node') . '/images/default.jpg';
     }
+
     $variables['default_image'] = [
       '#theme' => 'image',
       '#uri' => $image_url,

--- a/modules/wri_node/wri_node.module
+++ b/modules/wri_node/wri_node.module
@@ -7,8 +7,8 @@
 
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\node\NodeInterface;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
 use Drupal\wri_node\General;
 
@@ -75,8 +75,7 @@ function wri_node_preprocess_layout__card(&$variables) {
           // Get default image from default by name.
           $name = $term->name->value;
           $image_url = \Drupal::service('extension.list.module')
-              ->getPath('wri_node') . '/images/' .
-            strtolower(str_replace(' ', '-', $name)) . '.jpg';
+              ->getPath('wri_node') . '/images/' . strtolower(str_replace(' ', '-', $name)) . '.jpg';
           if (!file_exists($image_url)) {
             $image_url = \Drupal::service('extension.list.module')
                 ->getPath('wri_node') . '/images/default.jpg';

--- a/modules/wri_node/wri_node.module
+++ b/modules/wri_node/wri_node.module
@@ -7,11 +7,10 @@
 
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\node\NodeInterface;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
 use Drupal\wri_node\General;
-use Drupal\taxonomy\Entity\Term;
-use Drupal\file\Entity\File;
 
 /**
  * Implements hook_preprocess_hook().
@@ -76,7 +75,8 @@ function wri_node_preprocess_layout__card(&$variables) {
           // Get default image from default by name.
           $name = $term->name->value;
           $image_url = \Drupal::service('extension.list.module')
-              ->getPath('wri_node') . '/images/' . strtolower(str_replace(' ', '-', $name)) . '.jpg';
+              ->getPath('wri_node') . '/images/' .
+            strtolower(str_replace(' ', '-', $name)) . '.jpg';
           if (!file_exists($image_url)) {
             $image_url = \Drupal::service('extension.list.module')
                 ->getPath('wri_node') . '/images/default.jpg';

--- a/modules/wri_node/wri_node.module
+++ b/modules/wri_node/wri_node.module
@@ -8,8 +8,8 @@
 use Drupal\image\Entity\ImageStyle;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
-use Drupal\taxonomy\Entity\Term;
 use Drupal\responsive_image\Entity\ResponsiveImageStyle;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\wri_node\General;
 
 /**
@@ -75,10 +75,10 @@ function wri_node_preprocess_layout__card(&$variables) {
           // Get default image from default by name.
           $name = $term->name->value;
           $image_url = \Drupal::service('extension.list.module')
-              ->getPath('wri_node') . '/images/' . strtolower(str_replace(' ', '-', $name)) . '.jpg';
+            ->getPath('wri_node') . '/images/' . strtolower(str_replace(' ', '-', $name)) . '.jpg';
           if (!file_exists($image_url)) {
             $image_url = \Drupal::service('extension.list.module')
-                ->getPath('wri_node') . '/images/default.jpg';
+              ->getPath('wri_node') . '/images/default.jpg';
           }
         }
       }
@@ -86,7 +86,7 @@ function wri_node_preprocess_layout__card(&$variables) {
     else {
       // Get default image.
       $image_url = \Drupal::service('extension.list.module')
-          ->getPath('wri_node') . '/images/default.jpg';
+        ->getPath('wri_node') . '/images/default.jpg';
     }
 
     $variables['default_image'] = [

--- a/modules/wri_node/wri_node.module
+++ b/modules/wri_node/wri_node.module
@@ -64,12 +64,14 @@ function wri_node_preprocess_layout__card(&$variables) {
     $node = $variables['content']['#node'];
     $topic = $node->field_primary_topic->target_id;
     $image_url = '';
+    $theme = 'image';
     if ($topic) {
       // Get default image form term.
       $term = Term::load($topic);
       if ($term) {
-        if ($term->field_default_image->target_id) {
+        if ($term->field_default_image && $term->field_default_image->target_id) {
           $image_url = $term->field_default_image->entity->getFileUri();
+          $theme = 'image_style';
         }
         else {
           // Get default image from default by name.
@@ -90,7 +92,8 @@ function wri_node_preprocess_layout__card(&$variables) {
     }
 
     $variables['default_image'] = [
-      '#theme' => 'image',
+      '#theme' => $theme,
+      '#style_name' => '463x330',
       '#uri' => $image_url,
       '#alt' => '',
     ];


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [x] Issue Number: [#WRIN/TODO](https://github.com/wri/wriflagship/issues/809)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Added a new functionality to get image from taxonomy term if not continue with the current behavior to get default image by name or by a default image if there is not a taxonomy term.
-
-
-

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1082

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
