### PR TITLE
#403 added fix on subpages parent page menu link

### DIFF
--- a/modules/wri_subpage/wri_subpage.module
+++ b/modules/wri_subpage/wri_subpage.module
@@ -20,7 +20,7 @@ function wri_subpage_node_insert(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_update().
  */
 function wri_subpage_node_update(EntityInterface $entity) {
-  if (isset($entity->field_parent_page)) {
+  if ($entity->hasField('field_parent_page') && $entity->field_parent_page->getValue()) {
     $parentPage = $entity->field_parent_page->getValue();
     $oriParentPage = $entity->original->field_parent_page->getValue();
     if ($parentPage[0]['target_id'] !== $oriParentPage[0]['target_id']) {

--- a/modules/wri_subpage/wri_subpage.module
+++ b/modules/wri_subpage/wri_subpage.module
@@ -43,7 +43,7 @@ function wri_subpage_node_update(EntityInterface $entity) {
           $parent_link_menu_id = $parent_link_menu->getPluginId();
         }
 
-        // Save the current page as a child of the parent in the appropriate menu.
+        // Save the current page as a child's parent in the appropriate menu.
         $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
         if (!$current_link_menu_menu) {
           $current_link_menu = MenuLinkContent::create([

--- a/modules/wri_subpage/wri_subpage.module
+++ b/modules/wri_subpage/wri_subpage.module
@@ -21,43 +21,47 @@ function wri_subpage_node_insert(EntityInterface $entity) {
  */
 function wri_subpage_node_update(EntityInterface $entity) {
   if (isset($entity->field_parent_page)) {
-    $parent = $entity->field_parent_page->entity;
-    if ($parent && $parent->id()) {
-      // Set the correct menu for microsites vs all others.
-      'microsite' == $parent->bundle() ? $menu_name = 'microsites' : $menu_name = 'page-hierarchies';
-      $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+    $parentPage = $entity->field_parent_page->getValue();
+    $oriParentPage = $entity->original->field_parent_page->getValue();
+    if ($parentPage[0]['target_id'] !== $oriParentPage[0]['target_id']) {
+      $parent = $entity->field_parent_page->entity;
+      if ($parent && $parent->id()) {
+        // Set the correct menu for microsites vs all others.
+        'microsite' == $parent->bundle() ? $menu_name = 'microsites' : $menu_name = 'page-hierarchies';
+        $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
 
-      // Save the parent at the root of the menu, if not already there.
-      $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], $menu_name));
-      if (!$parent_link_menu_id) {
-        $parent_link_menu = MenuLinkContent::create([
-          'title' => $parent->label(),
-          'link' => ['uri' => 'entity:node/' . $parent->id()],
-          'menu_name' => $menu_name,
-          'expanded' => TRUE,
-        ]);
-        $parent_link_menu->save();
-        $parent_link_menu_id = $parent_link_menu->getPluginId();
-      }
+        // Save the parent at the root of the menu, if not already there.
+        $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], $menu_name));
+        if (!$parent_link_menu_id) {
+          $parent_link_menu = MenuLinkContent::create([
+            'title' => $parent->label(),
+            'link' => ['uri' => 'entity:node/' . $parent->id()],
+            'menu_name' => $menu_name,
+            'expanded' => TRUE,
+          ]);
+          $parent_link_menu->save();
+          $parent_link_menu_id = $parent_link_menu->getPluginId();
+        }
 
-      // Save the current page as a child of the parent in the appropriate menu.
-      $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
-      if (!$current_link_menu_menu) {
-        $current_link_menu = MenuLinkContent::create([
-          'title' => $entity->label(),
-          'link' => ['uri' => 'entity:node/' . $entity->id()],
-          'menu_name' => $menu_name,
-          'parent' => $parent_link_menu_id,
-          'expanded' => TRUE,
-        ]);
+        // Save the current page as a child of the parent in the appropriate menu.
+        $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
+        if (!$current_link_menu_menu) {
+          $current_link_menu = MenuLinkContent::create([
+            'title' => $entity->label(),
+            'link' => ['uri' => 'entity:node/' . $entity->id()],
+            'menu_name' => $menu_name,
+            'parent' => $parent_link_menu_id,
+            'expanded' => TRUE,
+          ]);
+        }
+        else {
+          $current_link_menu_id = current($current_link_menu_menu)->getPluginDefinition()["metadata"]["entity_id"];
+          $current_link_menu = MenuLinkContent::load($current_link_menu_id);
+          $current_link_menu->set('enabled', 1);
+          $current_link_menu->set('parent', $parent_link_menu_id);
+        }
+        $current_link_menu->save();
       }
-      else {
-        $current_link_menu_id = current($current_link_menu_menu)->getPluginDefinition()["metadata"]["entity_id"];
-        $current_link_menu = MenuLinkContent::load($current_link_menu_id);
-        $current_link_menu->set('enabled', 1);
-        $current_link_menu->set('parent', $parent_link_menu_id);
-      }
-      $current_link_menu->save();
     }
   }
 }


### PR DESCRIPTION
## What issue(s) does this solve?
We had a fix for this in place before, but the issue has come back where when you save a subpage, it automatically gets re-added to its respective project page menu. 
- [x] Issue Number: #WRIN/403

## What is the new behavior?
Added a fix and added conditions for change value on page parent to generate auto menu link

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
