### PR TITLE
adjust breakpoint that main menu is hidden #288

### DIFF
--- a/themes/custom/ts_wrin/sass/global/_header.scss
+++ b/themes/custom/ts_wrin/sass/global/_header.scss
@@ -275,7 +275,7 @@ header nav.menu--main {
     @include mq(900px) {
       display: none;
     }
-    @include mq(1275px) {
+    @include mq(1200px) {
       display: block;
     }
   }


### PR DESCRIPTION
## What issue(s) does this solve?

Adjust breakpoint at which the man nav hides

- [x] Issue Number: https://github.com/wri/wri-brasil/issues/288

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Both header navs should hide at 1200px viewport.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
