### PR TITLE
Revert "Merge pull request #204 from wri/403-subpages-subnav"

### DIFF
--- a/modules/wri_subpage/wri_subpage.module
+++ b/modules/wri_subpage/wri_subpage.module
@@ -42,7 +42,9 @@ function wri_subpage_node_update(EntityInterface $entity) {
 
       // Save the current page as a child of the parent in the appropriate menu.
       $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
-      if (!$current_link_menu_menu) {
+      if (!$current_link_menu_menu && !$entity->original) {
+        // Create a new menu link, but only if this is a new node. Otherwise
+        // clicking "Provide a menu link" to "Off" does not stick.
         $current_link_menu = MenuLinkContent::create([
           'title' => $entity->label(),
           'link' => ['uri' => 'entity:node/' . $entity->id()],
@@ -51,13 +53,15 @@ function wri_subpage_node_update(EntityInterface $entity) {
           'expanded' => TRUE,
         ]);
       }
-      else {
+      elseif ($current_link_menu_menu) {
         $current_link_menu_id = current($current_link_menu_menu)->getPluginDefinition()["metadata"]["entity_id"];
         $current_link_menu = MenuLinkContent::load($current_link_menu_id);
         $current_link_menu->set('enabled', 1);
         $current_link_menu->set('parent', $parent_link_menu_id);
       }
-      $current_link_menu->save();
+      if (isset($current_link_menu)) {
+        $current_link_menu->save();
+      }
     }
   }
 }
@@ -67,13 +71,15 @@ function wri_subpage_node_update(EntityInterface $entity) {
  */
 function wri_subpage_form_node_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $node = $form_state->getFormObject()->getEntity();
-  if (isset($node->field_parent_page->value)) {
-    $value = '';
-    if (isset($node->field_parent_page->entity)) {
-      $value = $node->field_parent_page->entity->label();
+  if ($form['menu']['enabled']['#default_value'] === 0 && isset($node->field_parent_page->target_id)) {
+    $parent = $node->field_parent_page->entity;
+    if ($parent && $parent->id()) {
+      // Set the correct menu for microsites vs all others.
+      'microsite' == $parent->bundle() ? $menu_name = 'microsites' : $menu_name = 'page-hierarchies';
+      $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+      $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], $menu_name));
+      $form['menu']['link']['menu_parent']['#default_value'] = $menu_name . ':' . $parent_link_menu_id;
+      $form['menu']['link']['menu_parent']['#description'] = t('Parent suggestion set from the "Parent page" field.');
     }
-    $form['menu']['link']['menu_parent']['#type'] = 'item';
-    $form['menu']['link']['menu_parent']['#markup'] = $value;
-    $form['menu']['link']['menu_parent']['#description'] = t('Parent will be pulled from the "Parent page" field.');
   }
 }

--- a/modules/wri_subpage/wri_subpage.module
+++ b/modules/wri_subpage/wri_subpage.module
@@ -20,48 +20,44 @@ function wri_subpage_node_insert(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_update().
  */
 function wri_subpage_node_update(EntityInterface $entity) {
-  if (isset($entity->original) && $entity->hasField('field_parent_page') && $entity->field_parent_page->getValue()) {
-    $parentPage = $entity->field_parent_page->getValue();
-    $oriParentPage = $entity->original->field_parent_page->getValue();
-    if ($parentPage[0]['target_id'] !== $oriParentPage[0]['target_id']) {
-      $parent = $entity->field_parent_page->entity;
-      if ($parent && $parent->id()) {
-        // Set the correct menu for microsites vs all others.
-        'microsite' == $parent->bundle() ? $menu_name = 'microsites' : $menu_name = 'page-hierarchies';
-        $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
+  if (isset($entity->field_parent_page)) {
+    $parent = $entity->field_parent_page->entity;
+    if ($parent && $parent->id()) {
+      // Set the correct menu for microsites vs all others.
+      'microsite' == $parent->bundle() ? $menu_name = 'microsites' : $menu_name = 'page-hierarchies';
+      $menu_link_manager = \Drupal::service('plugin.manager.menu.link');
 
-        // Save the parent at the root of the menu, if not already there.
-        $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], $menu_name));
-        if (!$parent_link_menu_id) {
-          $parent_link_menu = MenuLinkContent::create([
-            'title' => $parent->label(),
-            'link' => ['uri' => 'entity:node/' . $parent->id()],
-            'menu_name' => $menu_name,
-            'expanded' => TRUE,
-          ]);
-          $parent_link_menu->save();
-          $parent_link_menu_id = $parent_link_menu->getPluginId();
-        }
-
-        // Save the current page as a child's parent in the appropriate menu.
-        $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
-        if (!$current_link_menu_menu) {
-          $current_link_menu = MenuLinkContent::create([
-            'title' => $entity->label(),
-            'link' => ['uri' => 'entity:node/' . $entity->id()],
-            'menu_name' => $menu_name,
-            'parent' => $parent_link_menu_id,
-            'expanded' => TRUE,
-          ]);
-        }
-        else {
-          $current_link_menu_id = current($current_link_menu_menu)->getPluginDefinition()["metadata"]["entity_id"];
-          $current_link_menu = MenuLinkContent::load($current_link_menu_id);
-          $current_link_menu->set('enabled', 1);
-          $current_link_menu->set('parent', $parent_link_menu_id);
-        }
-        $current_link_menu->save();
+      // Save the parent at the root of the menu, if not already there.
+      $parent_link_menu_id = array_key_first($menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $parent->id()], $menu_name));
+      if (!$parent_link_menu_id) {
+        $parent_link_menu = MenuLinkContent::create([
+          'title' => $parent->label(),
+          'link' => ['uri' => 'entity:node/' . $parent->id()],
+          'menu_name' => $menu_name,
+          'expanded' => TRUE,
+        ]);
+        $parent_link_menu->save();
+        $parent_link_menu_id = $parent_link_menu->getPluginId();
       }
+
+      // Save the current page as a child of the parent in the appropriate menu.
+      $current_link_menu_menu = $menu_link_manager->loadLinksByRoute('entity.node.canonical', ['node' => $entity->id()], $menu_name);
+      if (!$current_link_menu_menu) {
+        $current_link_menu = MenuLinkContent::create([
+          'title' => $entity->label(),
+          'link' => ['uri' => 'entity:node/' . $entity->id()],
+          'menu_name' => $menu_name,
+          'parent' => $parent_link_menu_id,
+          'expanded' => TRUE,
+        ]);
+      }
+      else {
+        $current_link_menu_id = current($current_link_menu_menu)->getPluginDefinition()["metadata"]["entity_id"];
+        $current_link_menu = MenuLinkContent::load($current_link_menu_id);
+        $current_link_menu->set('enabled', 1);
+        $current_link_menu->set('parent', $parent_link_menu_id);
+      }
+      $current_link_menu->save();
     }
   }
 }


### PR DESCRIPTION
This reverts commit dcb1624d6d1751b6ca78640f7e174dfc0a0d335c, reversing changes made to 9f71518d00d4152400447bf5340e81bafb045d9a.

## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [x] Issue Number: https://github.com/wri/WRIN/issues/403

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Undoes what turned out to be an overly-heavy correction to the update behavior, and updates the edit form to merely suggest what the parent menu item should be, if a parent item is set.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
