### PR TITLE
301 translations

### DIFF
--- a/modules/wri_engagement/config/install/views.view.node_downloads.yml
+++ b/modules/wri_engagement/config/install/views.view.node_downloads.yml
@@ -265,15 +265,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        content_translation_source:
-          id: content_translation_source
+        langcode:
+          id: langcode
           table: node_field_data
-          field: content_translation_source
+          field: langcode
           relationship: none
           group_type: group
           admin_label: ''
           entity_type: node
-          entity_field: content_translation_source
+          entity_field: langcode
           plugin_id: language
           operator: in
           value:
@@ -362,6 +362,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      rendering_language: '***LANGUAGE_language_interface***'
       display_extenders:
         metatag_display_extender:
           metatags: {  }
@@ -370,7 +371,6 @@ display:
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - user

--- a/modules/wri_engagement/config/install/views.view.node_downloads.yml
+++ b/modules/wri_engagement/config/install/views.view.node_downloads.yml
@@ -85,69 +85,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-        field_files_1:
-          id: field_files_1
-          table: node__field_files
-          field: field_files
-          relationship: field_parent_page
-          group_type: group
-          admin_label: ''
-          plugin_id: field
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_entity_view
-          settings:
-            view_mode: download_listing
-          group_column: target_id
-          group_columns: {  }
-          group_rows: false
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
       pager:
         type: none
         options:

--- a/modules/wri_engagement/wri_engagement.module
+++ b/modules/wri_engagement/wri_engagement.module
@@ -5,7 +5,6 @@
  * Contains wri_engagement.module.
  */
 
-use Drupal\node\NodeInterface;
 use Drupal\webform\Entity\Webform;
 
 /**

--- a/modules/wri_engagement/wri_engagement.module
+++ b/modules/wri_engagement/wri_engagement.module
@@ -29,16 +29,12 @@ function wri_engagement_theme() {
  * Implements hook_preprocess_HOOK().
  */
 function wri_engagement_preprocess_download_modal(&$variables) {
-  $node = \Drupal::routeMatch()->getParameter('node');
+  $nid = $variables['content']['#object']->id();
   $language = \Drupal::languageManager()->getCurrentLanguage();
   $prefixes = \Drupal::config('language.negotiation')->get('url.prefixes');
   $language_prefix = $prefixes[$language->getId()] ? '/' . $prefixes[$language->getId()] : '';
   $interrupter_webform = FALSE;
 
-  if ($node instanceof NodeInterface) {
-    $nid = $node->id();
-    // Do whatever you need to do with the node ID here...
-  }
   $interrupter_webform_id = Drupal::config('wri_engagement.settings')->get('download_interrupter');
   if ($interrupter_webform_id) {
     $interrupter_webform = Webform::load($interrupter_webform_id);

--- a/modules/wri_engagement/wri_engagement.module
+++ b/modules/wri_engagement/wri_engagement.module
@@ -32,7 +32,7 @@ function wri_engagement_preprocess_download_modal(&$variables) {
   $node = \Drupal::routeMatch()->getParameter('node');
   $language = \Drupal::languageManager()->getCurrentLanguage();
   $prefixes = \Drupal::config('language.negotiation')->get('url.prefixes');
-  $language_prefix = isset($prefixes[$language->getId()]) ? '/' . $prefixes[$language->getId()] : '';
+  $language_prefix = $prefixes[$language->getId()] ? '/' . $prefixes[$language->getId()] : '';
   $interrupter_webform = FALSE;
 
   if ($node instanceof NodeInterface) {

--- a/modules/wri_engagement/wri_engagement.module
+++ b/modules/wri_engagement/wri_engagement.module
@@ -30,6 +30,9 @@ function wri_engagement_theme() {
  */
 function wri_engagement_preprocess_download_modal(&$variables) {
   $node = \Drupal::routeMatch()->getParameter('node');
+  $language = \Drupal::languageManager()->getCurrentLanguage();
+  $prefixes = \Drupal::config('language.negotiation')->get('url.prefixes');
+  $language_prefix = isset($prefixes[$language->getId()]) ? '/' . $prefixes[$language->getId()] : '';
   $interrupter_webform = FALSE;
 
   if ($node instanceof NodeInterface) {
@@ -49,7 +52,7 @@ function wri_engagement_preprocess_download_modal(&$variables) {
     }
   }
   else {
-    $variables['webform_url'] = '/node/' . $nid . '/download';
+    $variables['webform_url'] = $language_prefix . '/node/' . $nid . '/download';
     $variables['webform_title'] = t('Download Publication');
     $variables['classes'] = 'use-ajax';
   }


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/WRIN/issues/301

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes subpages to use the parent's node id, avoiding duplicates on translations
- Allows you to pass a translation value to the view: `/node/815/download` and `/en/node/815/download`

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [x] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] China PR: https://github.com/wri/wri-china/pull/422
