### PR TITLE
Locking core to 10.2.x so we don't have to update patches.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "drupal/config_partial_export": "^2.0@alpha",
         "drupal/content_snippets": "^2.0",
         "drupal/core-composer-scaffold": "^10.0",
-        "drupal/core-recommended": "^10.0",
+        "drupal/core-recommended": "~10.2.0",
         "drupal/ctools": "^4.0",
         "drupal/diff": "^1.0",
         "drupal/ds": "^5.0.0",


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Builds started failing when we upgraded to 10.3.0, so locking to 10.2.x until https://github.com/wri/wri_sites/issues/278 is done

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
