### PR TITLE
Revert "Issue #1047 pulling block description to the label if it isn'…

### DIFF
--- a/themes/custom/ts_wrin/templates/fields/field--block-content--field-featured-experts.html.twig
+++ b/themes/custom/ts_wrin/templates/fields/field--block-content--field-featured-experts.html.twig
@@ -14,7 +14,4 @@
   </div>
 {% endset %}
 {% endif %}
-{% if element['#object'].info.value %}
-{% set label = element['#object'].info.value %}
-{% endif %}
 {% include "@ts_wrin/fields/field--node--field-featured-experts.html.twig" %}

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -101,6 +101,17 @@ function ts_wrin_theme_suggestions_container_alter(array &$suggestions, array $v
 }
 
 /**
+ * Implements hook_preprocess_HOOK() for paragraph templates.
+ */
+function ts_wrin_preprocess_paragraph(array &$variables) {
+  // On person listing paragraphs, get the field title from the block title.
+  // Person listing blocks do this automatically.
+  if ($variables['paragraph']->getType() == 'person_listing') {
+    $variables["elements"]["field_block"][0]["field_featured_experts"]['#object']->overridden_label = $variables["elements"]["field_block"][0]["#block_content"]->info->value ?? NULL;
+  }
+}
+
+/**
  * Implements hook_preprocess_page() for page.html.twig.
  */
 function ts_wrin_preprocess_page(array &$variables) {
@@ -161,9 +172,11 @@ function ts_wrin_preprocess_field(array &$variables) {
     $variables["attributes"]["class"] = $variables["element"][0]["#attributes"]["class"];
     $variables["attributes"]["class"][] = 'block';
   }
-  // Add 'Show More Link' value to Featured Experts field.
+  // Add 'Show More Link' value to Featured Experts field and set the label to
+  // the block description for blocks embedded as paragraphs.
   if ($variables['element']['#field_name'] == 'field_featured_experts') {
     $object = $variables['element']['#object'];
+    $variables['label'] = $variables["element"]["#object"]->overridden_label ?? $variables['label'];
     if (isset($object->field_show_more_link)) {
       $variables["show_more_link"] = $object->field_show_more_link->value;
     }


### PR DESCRIPTION
…t already."

This reverts commit a9d3e89ec34ad5a940973435889c765633d287c1.

## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/wri_sites/issues/294

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Alters how we change the label for the block_content featured_expert field to happen in php instead of twig.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wri-indonesia/pull/74

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
