### PR TITLE
WRI #452 Report/publication teaser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -163,7 +163,7 @@
         "drupal/redirect": "^1.7",
         "drupal/redis": "^1.5",
         "drupal/rename_admin_paths": "^2.2",
-        "drupal/responsive_tables_filter": "^1.9",
+        "drupal/responsive_tables_filter": "^1.19",
         "drupal/scheduled_transitions": "^2.2",
         "drupal/schema_metatag": "^3.0",
         "drupal/search_api": "^1.34",

--- a/modules/wri_admin/css/admin.css
+++ b/modules/wri_admin/css/admin.css
@@ -187,3 +187,7 @@ form .fieldset {
 #auto-generate-password {
   width: 1.25rem;
 }
+
+.report-teaser figure {
+  margin: 0 0 20px 0;
+}

--- a/modules/wri_admin/templates/ckeditor5_template.json
+++ b/modules/wri_admin/templates/ckeditor5_template.json
@@ -1,9 +1,9 @@
 [
     {
-        "title": "Callout Center",
-        "icon": "",
-        "description": "",
-        "html": "<div class=\"callout\"><p class=\"secondary body-link\"><strong>Callout Top Text</strong></p><p class=\"secondary\">Callout Bottom Text</p></div>"
+      "title": "Callout Center",
+      "icon": "",
+      "description": "",
+      "html": "<div class=\"callout\"><p class=\"secondary body-link\"><strong>Callout Top Text</strong></p><p class=\"secondary\">Callout Bottom Text</p></div>"
     },
     {
       "title": "Callout Left",
@@ -22,5 +22,11 @@
       "icon": "",
       "description": "",
       "html": "<div class=\"bullets border-small\"><div class=\"h4 bottom-border-tiny-black\">Stuff you need to know</div><ul><li><strong>Bullet Title:</strong> List item 1 content</li><li><strong>Bullet Title 2:</strong> List item 2 content</li></ul></div>"
+    },
+    {
+      "title": "Report Teaser",
+      "icon": "",
+      "description": "",
+      "html": "<div class=\"report-teaser gold-borders-medium\"><div class=\"image-wrapper\">Optional Image - set to 'Thumbnail'</div><div class=\"text-wrapper\"><div class=\"h4 topic-tag\">Report/Publication</div><p>Teaser text for the report or publication.</p><p><a href=\"/resources\" download class=\"button small\">Download</a></p></div></div>"
     }
 ]

--- a/modules/wri_admin/templates/ckeditor5_template.json
+++ b/modules/wri_admin/templates/ckeditor5_template.json
@@ -27,6 +27,6 @@
       "title": "Report Teaser",
       "icon": "",
       "description": "",
-      "html": "<div class=\"report-teaser gold-borders-medium\"><div class=\"image-wrapper\">Optional Image - set to 'Thumbnail'</div><div class=\"text-wrapper\"><div class=\"h4 topic-tag\">Report/Publication</div><p>Teaser text for the report or publication.</p><p><a href=\"/resources\" download class=\"button small\">Download</a></p></div></div>"
+      "html": "<div class=\"report-teaser gold-borders-medium alignright\"><div class=\"image-wrapper\">Optional Image - set to 'Thumbnail'</div><div class=\"text-wrapper\"><div class=\"h4 topic-tag\">Report/Pub Title</div><p>Teaser text for the report or publication.</p><p><a href=\"/resources\" download class=\"button small\">Download</a></p></div></div>"
     }
 ]

--- a/modules/wri_media/config/install/core.entity_view_display.media.image.thumbnail.yml
+++ b/modules/wri_media/config/install/core.entity_view_display.media.image.thumbnail.yml
@@ -10,7 +10,6 @@ dependencies:
     - media.type.image
   module:
     - layout_builder
-    - svg_image
 third_party_settings:
   layout_builder:
     enabled: false

--- a/modules/wri_media/config/install/core.entity_view_display.media.image.thumbnail.yml
+++ b/modules/wri_media/config/install/core.entity_view_display.media.image.thumbnail.yml
@@ -1,0 +1,46 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.thumbnail
+    - field.field.media.image.field_attribution
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_tags
+    - image.style.180x240_scale
+    - media.type.image
+  module:
+    - layout_builder
+    - svg_image
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: media.image.thumbnail
+targetEntityType: media
+bundle: image
+mode: thumbnail
+content:
+  field_media_image:
+    type: image
+    label: hidden
+    settings:
+      image_link: ''
+      image_style: 180x240_scale
+      image_loading:
+        attribute: lazy
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: false
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  created: true
+  field_attribution: true
+  field_tags: true
+  langcode: true
+  name: true
+  search_api_excerpt: true
+  thumbnail: true
+  uid: true

--- a/modules/wri_media/config/install/core.entity_view_mode.media.thumbnail.yml
+++ b/modules/wri_media/config/install/core.entity_view_mode.media.thumbnail.yml
@@ -1,0 +1,11 @@
+uuid: c69bc5e6-67ae-4594-a478-5090599a0e64
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.thumbnail
+label: Thumbnail
+description: ''
+targetEntityType: media
+cache: true

--- a/modules/wri_media/config/install/filter.format.full_html.yml
+++ b/modules/wri_media/config/install/filter.format.full_html.yml
@@ -5,6 +5,7 @@ dependencies:
     - core.entity_view_mode.media.full
     - core.entity_view_mode.media.full_width
     - core.entity_view_mode.media.half_content
+    - core.entity_view_mode.media.thumbnail
   module:
     - editor
     - media
@@ -41,10 +42,10 @@ filters:
   filter_html:
     id: filter_html
     provider: filter
-    status: true
+    status: false
     weight: -50
     settings:
-      allowed_html: '<br> <p class="secondary text-align-left text-align-center text-align-right text-align-justify"> <h2 class="text-align-left text-align-center text-align-right text-align-justify"> <h3 class="text-align-left text-align-center text-align-right text-align-justify"> <h4 class="text-align-left text-align-center text-align-right text-align-justify"> <h5 class="text-align-left text-align-center text-align-right text-align-justify"> <h6 class="text-align-left text-align-center text-align-right text-align-justify"> <a class href aria-label title id target="_blank" rel> <span class="drop-cap"> <div class> <strong> <em> <s> <sub> <sup> <blockquote> <ul> <ol reversed start> <li> <hr> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <drupal-media data-entity-type data-entity-uuid alt data-view-mode data-caption data-align> <dl class> <dt> <dd>'
+      allowed_html: '<div class> <a name class="button"> <span class="drop-cap"> <p class="secondary">'
       filter_html_help: false
       filter_html_nofollow: false
   filter_html_escape:
@@ -78,7 +79,7 @@ filters:
     weight: -48
     settings:
       tablesaw_type: stack
-      tablesaw_persist: '0'
+      tablesaw_persist: false
   filter_url:
     id: filter_url
     provider: filter
@@ -97,6 +98,7 @@ filters:
         full: full
         full_width: full_width
         half_content: half_content
+        thumbnail: thumbnail
       allowed_media_types: {  }
   token_filter:
     id: token_filter
@@ -104,4 +106,4 @@ filters:
     status: false
     weight: -40
     settings:
-      replace_empty: '0'
+      replace_empty: false

--- a/modules/wri_media/config/install/image.style.180x240_scale.yml
+++ b/modules/wri_media/config/install/image.style.180x240_scale.yml
@@ -1,4 +1,3 @@
-uuid: 3563c28d-4760-4d49-a06d-082ffd4af8fb
 langcode: en
 status: true
 dependencies: {  }

--- a/modules/wri_media/config/install/image.style.180x240_scale.yml
+++ b/modules/wri_media/config/install/image.style.180x240_scale.yml
@@ -1,0 +1,15 @@
+uuid: 3563c28d-4760-4d49-a06d-082ffd4af8fb
+langcode: en
+status: true
+dependencies: {  }
+name: 180x240_scale
+label: '180x240 scale'
+effects:
+  0886dc7e-d080-4e13-ac4f-ef467352d1fd:
+    uuid: 0886dc7e-d080-4e13-ac4f-ef467352d1fd
+    id: image_scale
+    weight: 1
+    data:
+      width: 180
+      height: 240
+      upscale: true

--- a/modules/wri_media/wri_media.info.yml
+++ b/modules/wri_media/wri_media.info.yml
@@ -46,6 +46,7 @@ config_devel:
     - core.entity_view_display.media.image.large_image_teaser
     - core.entity_view_display.media.image.media_library
     - core.entity_view_display.media.image.superfeatured
+    - core.entity_view_display.media.image.thumbnail
     - core.entity_view_display.media.image.tile
     - core.entity_view_display.media.video.default
     - core.entity_view_display.media.video.media_library
@@ -99,6 +100,7 @@ config_devel:
     - image.style.150_tall
     - image.style.150_wide
     - image.style.1575_wide
+    - image.style.180x240_scale
     - image.style.2000x1160
     - image.style.2000x695
     - image.style.2000x765

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -79,3 +79,12 @@ function wri_media_update_10102() {
     'settings#plugins#ckeditor5_sourceEditing#allowed_tags',
   ], 'wri_media', 'install');
 }
+
+/**
+ * Update filter thumbnail media settings.
+ */
+function wri_media_update_10103() {
+  \Drupal::service('distro_helper.updates')->installConfig('filter.format.full_html', 'wri_media', 'install', 'TRUE');
+  \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail.yml', 'wri_media', 'install', 'TRUE');
+  \Drupal::service('distro_helper.updates')->installConfig('filter.format.full_html', 'wri_media', 'install', 'TRUE');
+}

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -84,8 +84,9 @@ function wri_media_update_10102() {
  * Update filter thumbnail media settings.
  */
 function wri_media_update_10103() {
-  \Drupal::service('distro_helper.updates')->installConfig('filter.format.full_html', 'wri_media', 'install', 'TRUE');
+  \Drupal::service('distro_helper.updates')->updateConfig('filter.format.full_html', [
+    'filters#media_embed#settings#allowed_view_modes#half_content',
+  ] 'wri_media');
   \Drupal::service('distro_helper.updates')->installConfig('image.style.180x240_scale', 'wri_media', 'install', 'TRUE');
   \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail', 'wri_media', 'install', 'TRUE');
-  \Drupal::service('distro_helper.updates')->installConfig('filter.format.full_html', 'wri_media', 'install', 'TRUE');
 }

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -85,7 +85,7 @@ function wri_media_update_10102() {
  */
 function wri_media_update_10103() {
   \Drupal::service('distro_helper.updates')->updateConfig('filter.format.full_html', [
-    'filters#media_embed#settings#allowed_view_modes#half_content',
+    'filters#media_embed#settings#allowed_view_modes#thumbnail',
   ], 'wri_media');
   \Drupal::service('distro_helper.updates')->installConfig('image.style.180x240_scale', 'wri_media', 'install', 'TRUE');
   \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail', 'wri_media', 'install', 'TRUE');

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -86,7 +86,7 @@ function wri_media_update_10102() {
 function wri_media_update_10103() {
   \Drupal::service('distro_helper.updates')->updateConfig('filter.format.full_html', [
     'filters#media_embed#settings#allowed_view_modes#half_content',
-  ] 'wri_media');
+  ], 'wri_media');
   \Drupal::service('distro_helper.updates')->installConfig('image.style.180x240_scale', 'wri_media', 'install', 'TRUE');
   \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail', 'wri_media', 'install', 'TRUE');
 }

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -85,6 +85,7 @@ function wri_media_update_10102() {
  */
 function wri_media_update_10103() {
   \Drupal::service('distro_helper.updates')->installConfig('filter.format.full_html', 'wri_media', 'install', 'TRUE');
-  \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail.yml', 'wri_media', 'install', 'TRUE');
+  \Drupal::service('distro_helper.updates')->installConfig('image.style.180x240_scale', 'wri_media', 'install', 'TRUE');
+  \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail', 'wri_media', 'install', 'TRUE');
   \Drupal::service('distro_helper.updates')->installConfig('filter.format.full_html', 'wri_media', 'install', 'TRUE');
 }

--- a/themes/custom/ts_wrin/sass/ckeditor.scss
+++ b/themes/custom/ts_wrin/sass/ckeditor.scss
@@ -19,7 +19,8 @@
   }
 
   .callout.alignright,
-  blockquote p.text-align-right {
+  blockquote p.text-align-right,
+  .report-teaser.alignright {
     margin-right: 0;
   }
 

--- a/themes/custom/ts_wrin/sass/components/_programs.scss
+++ b/themes/custom/ts_wrin/sass/components/_programs.scss
@@ -317,3 +317,25 @@
   @extend .top-border-thick;
   @extend .margin-top-sm;
 }
+
+.report-teaser {
+  img {
+    max-height: 240px;
+    padding-bottom: $space-xs;
+    width: 180px;
+  }
+
+  p {
+    @include font($acumin-semi-cond, "semi-bold");
+    @include font-line-height(16);
+  }
+
+  @media (min-width:768px) and (max-width:991px) {
+    align-items: center;
+    display: flex;
+
+    .media--type-image {
+      padding-right: $space-xs;
+    }
+  }
+}

--- a/themes/custom/ts_wrin/sass/components/_programs.scss
+++ b/themes/custom/ts_wrin/sass/components/_programs.scss
@@ -327,7 +327,7 @@
 
   p {
     @include font($acumin-semi-cond, "semi-bold");
-    @include font-line-height(16);
+    @include font-line-height(18,26);
   }
 
   @media (min-width:768px) and (max-width:991px) {

--- a/themes/custom/ts_wrin/sass/components/_programs.scss
+++ b/themes/custom/ts_wrin/sass/components/_programs.scss
@@ -327,10 +327,10 @@
 
   p {
     @include font($acumin-semi-cond, "semi-bold");
-    @include font-line-height(18,26);
+    @include font-line-height(18, 26);
   }
 
-  @media (min-width:768px) and (max-width:991px) {
+  @media (min-width: 768px) and (max-width: 991px) {
     align-items: center;
     display: flex;
 

--- a/themes/custom/ts_wrin/sass/components/_programs.scss
+++ b/themes/custom/ts_wrin/sass/components/_programs.scss
@@ -318,24 +318,3 @@
   @extend .margin-top-sm;
 }
 
-.report-teaser {
-  img {
-    max-height: 240px;
-    padding-bottom: $space-xs;
-    width: 180px;
-  }
-
-  p {
-    @include font($acumin-semi-cond, "semi-bold");
-    @include font-line-height(18, 26);
-  }
-
-  @media (min-width: 768px) and (max-width: 991px) {
-    align-items: center;
-    display: flex;
-
-    .media--type-image {
-      padding-right: $space-xs;
-    }
-  }
-}

--- a/themes/custom/ts_wrin/sass/config/_04.base.scss
+++ b/themes/custom/ts_wrin/sass/config/_04.base.scss
@@ -294,6 +294,12 @@ figcaption {
   padding-top: $space-xs;
 }
 
+.gold-borders-medium {
+  border-bottom: 4px solid $brand-gold;
+  border-top: 4px solid $brand-gold;
+  padding-top: $space-xs;
+}
+
 ul.menu {
   margin: 0;
 }

--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -399,6 +399,54 @@ table {
   }
 }
 
-.report-teaser figure {
-  margin: 0 0 20px 0;
+.report-teaser {
+  @extend .secondary;
+  border-left: none;
+  padding: 20px 0 12px;
+  margin-top: $space-xs;
+
+  & p:first-child {
+    margin-top: 0;
+  }
+
+  &.alignleft p.secondary.body-link,
+  &.alignright p.secondary.body-link {
+    @include mq($md) {
+      &:first-of-type {
+        margin-top: 0;
+      }
+    }
+  }
+  img {
+    max-height: 240px;
+    padding-bottom: $space-xs;
+    width: 180px;
+  }
+
+  p {
+    @include font($acumin-semi-cond, "semi-bold");
+    @include font-line-height(18, 26);
+  }
+  figure {
+    margin: 0 0 20px 0;
+  }
+
+  @media (min-width: 768px) and (max-width: 1023px) {
+    align-items: center;
+    display: flex;
+
+    .media--type-image {
+      padding-right: $space-xs;
+    }
+  }
+  &.alignright {
+    @include mq($lg) {
+      display: inline;
+      float: right;
+      margin: 0 -25.7% 0 $space-sm;
+      width: 36%;
+      max-width: 180px;
+    }
+  }
 }
+

--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -398,3 +398,8 @@ table {
     height: 100%;
   }
 }
+
+.report-teaser figure {
+  margin: 0 0 20px 0;
+}
+

--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -443,10 +443,8 @@ table {
     @include mq($lg) {
       display: inline;
       float: right;
-      margin: 0 -25.7% 0 $space-sm;
-      width: 36%;
-      max-width: 180px;
+      margin: 0 230px 0 $space-sm;
+      width: 180px;
     }
   }
 }
-

--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -402,4 +402,3 @@ table {
 .report-teaser figure {
   margin: 0 0 20px 0;
 }
-


### PR DESCRIPTION
## What issue(s) does this solve?
Adds a CKEditor template for 'Report Teaser', with optional thumbnail image in a new 180x240 image size.

- [x] Issue Number: https://github.com/wri/WRIN/issues/452

## What is the new behavior?
- Version bump to responsive_tables_filter (was preventing the full_html text format from saving)
- adds 180x240_scale image style
- updated the 'thumbnail' media display mode to use the new image style
- Adds a CKEditor template: 'Report Teaser' with appropriate styling in both WYSIWYG and site display

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1211

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
