### PR TITLE
Wri 462  submenu

### DIFF
--- a/modules/wri_publication/templates/wri-publication-columns.html.twig
+++ b/modules/wri_publication/templates/wri-publication-columns.html.twig
@@ -72,6 +72,15 @@
 
 
       {% if content.category or content.share %}
+        {% if display_type == 'robust' and (content.hero.field_toc is not empty) and (content.hero.field_toc['#value'] != 'microsite') %}
+          <div class="mobile__toc grid">
+            <div class="internal-menu-pages">
+              {% set menu_title = content.hero.field_toc['#menu_title'] %}
+              {% set menu_link = content.hero.field_toc['#menu_link'] %}
+              {{ drupal_block('menu_block:' ~ menu_title, {level: 1, expand_all_items: 1, depth: 0, parent: menu_title ~ ':' ~ menu_link, render_parent: 0, follow_parent: 'child', follow: 0, label: 'Table of Contents', label_display: 0, id:'page-hierarchies', suggestion: 'page-hierarchies'}) }}
+            </div>
+           </div>
+        {% endif %}
         <div class="detail__meta meta grid margin-top-md margin-bottom-md">
           <div class="detail__meta-inner meta-inner {% if content.sidebar.field_narrative_taxonomy|render %}two-column{% endif %}">
             {% if content.category %}

--- a/modules/wri_publication/templates/wri-publication-columns.html.twig
+++ b/modules/wri_publication/templates/wri-publication-columns.html.twig
@@ -75,9 +75,19 @@
         {% if display_type == 'robust' and (content.hero.field_toc is not empty) and (content.hero.field_toc['#value'] != 'microsite') %}
           <div class="mobile__toc grid">
             <div class="internal-menu-pages">
+              {% set node_title = content.hero.field_toc['#node_title'] %}
               {% set menu_title = content.hero.field_toc['#menu_title'] %}
               {% set menu_link = content.hero.field_toc['#menu_link'] %}
-              {{ drupal_block('menu_block:' ~ menu_title, {level: 1, expand_all_items: 1, depth: 0, parent: menu_title ~ ':' ~ menu_link, render_parent: 0, follow_parent: 'child', follow: 0, label: 'Table of Contents', label_display: 0, id:'page-hierarchies', suggestion: 'page-hierarchies'}) }}
+              {% set value = content.hero.field_toc['#value'] %}
+              {% if  value == 1 %}
+              {{ attach_library('wri_toc/tocjs') }}
+                <div class="field-label" tabindex="0"><a tabindex="-1" href="#">{{ node_title }}</a></div>
+                <nav role="navigation" id="menu-toc" aria-label="Page sub navigation" class="page-hierarchies">
+                  <ul class="toc-list menu" data-toc="div.layout__region--content" data-toc-headings=".publication__main h2"></ul>
+                </nav>
+              {% else %}
+                {{ drupal_block('menu_block:' ~ menu_title, {level: 1, expand_all_items: 1, depth: 0, parent: menu_title ~ ':' ~ menu_link, render_parent: 0, follow_parent: 'child', follow: 0, label: 'Table of Contents', label_display: 0, id:'page-hierarchies', suggestion: 'page-hierarchies'}) }}
+              {% endif %}
             </div>
            </div>
         {% endif %}

--- a/modules/wri_subpage/templates/wri-subpage-columns.html.twig
+++ b/modules/wri_subpage/templates/wri-subpage-columns.html.twig
@@ -46,6 +46,25 @@
     {# end if content.hero #}
 
     {% if content.category or content.share %}
+      {% if (content.hero.field_toc is not empty) and (content.hero.field_toc['#value'] != 'microsite') %}
+        <div class="mobile__toc grid">
+          <div class="internal-menu-pages">
+            {% set node_title = content.hero.field_toc['#node_title'] %}
+            {% set menu_title = content.hero.field_toc['#menu_title'] %}
+            {% set menu_link = content.hero.field_toc['#menu_link'] %}
+            {% set value = content.hero.field_toc['#value'] %}
+            {% if  value == 1 %}
+            {{ attach_library('wri_toc/tocjs') }}
+              <div class="field-label" tabindex="0"><a tabindex="-1" href="#">{{ node_title }}</a></div>
+              <nav role="navigation" id="menu-toc" aria-label="Page sub navigation" class="page-hierarchies">
+                <ul class="toc-list menu" data-toc="div.layout__region--content" data-toc-headings=".publication__main h2"></ul>
+              </nav>
+            {% else %}
+              {{ drupal_block('menu_block:' ~ menu_title, {level: 1, expand_all_items: 1, depth: 0, parent: menu_title ~ ':' ~ menu_link, render_parent: 1, follow_parent: 'child', follow: 0, label: 'Table of Contents', label_display: 0, id:'page-hierarchies', suggestion: 'page-hierarchies'}) }}
+            {% endif %}
+          </div>
+         </div>
+      {% endif %}
       <div class="detail__meta meta grid margin-top-md margin-bottom-md">
         <div class="detail__meta-inner meta-inner {% if content.sidebar.field_narrative_taxonomy|render %}two-column{% endif %}">
           {% if content.category %}

--- a/themes/custom/ts_wrin/js/components/ts_header_nav.js
+++ b/themes/custom/ts_wrin/js/components/ts_header_nav.js
@@ -309,36 +309,38 @@ export default function(context) {
       }
     });
 
-    const menuContainer = document.querySelector('.internal-menu-pages');
-    const menuToggle = document.querySelector('.internal-menu-pages .field-label');
+    const menuContainer = document.querySelector(".internal-menu-pages");
+    const menuToggle = document.querySelector(
+      ".internal-menu-pages .field-label"
+    );
 
     if (menuContainer && menuToggle) {
       // Toggle menu open/closed when clicking the label
-      menuToggle.addEventListener('click', function (e) {
+      menuToggle.addEventListener("click", function(e) {
         e.preventDefault();
         e.stopPropagation(); // Stop event propagation to avoid interfering with links
 
         // Toggle the 'menu-open' and 'menu-closed' classes
-        if (menuContainer.classList.contains('menu-open')) {
-          menuContainer.classList.remove('menu-open');
-          menuContainer.classList.add('menu-closed');
+        if (menuContainer.classList.contains("menu-open")) {
+          menuContainer.classList.remove("menu-open");
+          menuContainer.classList.add("menu-closed");
         } else {
-          menuContainer.classList.remove('menu-closed');
-          menuContainer.classList.add('menu-open');
+          menuContainer.classList.remove("menu-closed");
+          menuContainer.classList.add("menu-open");
         }
       });
 
       // Prevent clicks within the menu from toggling the menu
-      menuContainer.querySelector('nav').addEventListener('click', function (e) {
+      menuContainer.querySelector("nav").addEventListener("click", function(e) {
         e.stopPropagation();
       });
     }
 
     // Close the menu if clicking outside of it
-    document.addEventListener('click', function () {
-      if (menuContainer.classList.contains('menu-open')) {
-        menuContainer.classList.remove('menu-open');
-        menuContainer.classList.add('menu-closed');
+    document.addEventListener("click", function() {
+      if (menuContainer.classList.contains("menu-open")) {
+        menuContainer.classList.remove("menu-open");
+        menuContainer.classList.add("menu-closed");
       }
     });
   }

--- a/themes/custom/ts_wrin/js/components/ts_header_nav.js
+++ b/themes/custom/ts_wrin/js/components/ts_header_nav.js
@@ -308,5 +308,38 @@ export default function(context) {
         }, 100);
       }
     });
+
+    const menuContainer = document.querySelector('.internal-menu-pages');
+    const menuToggle = document.querySelector('.internal-menu-pages .field-label');
+
+    if (menuContainer && menuToggle) {
+      // Toggle menu open/closed when clicking the label
+      menuToggle.addEventListener('click', function (e) {
+        e.preventDefault();
+        e.stopPropagation(); // Stop event propagation to avoid interfering with links
+
+        // Toggle the 'menu-open' and 'menu-closed' classes
+        if (menuContainer.classList.contains('menu-open')) {
+          menuContainer.classList.remove('menu-open');
+          menuContainer.classList.add('menu-closed');
+        } else {
+          menuContainer.classList.remove('menu-closed');
+          menuContainer.classList.add('menu-open');
+        }
+      });
+
+      // Prevent clicks within the menu from toggling the menu
+      menuContainer.querySelector('nav').addEventListener('click', function (e) {
+        e.stopPropagation();
+      });
+    }
+
+    // Close the menu if clicking outside of it
+    document.addEventListener('click', function () {
+      if (menuContainer.classList.contains('menu-open')) {
+        menuContainer.classList.remove('menu-open');
+        menuContainer.classList.add('menu-closed');
+      }
+    });
   }
 }

--- a/themes/custom/ts_wrin/sass/components/_simple-page.scss
+++ b/themes/custom/ts_wrin/sass/components/_simple-page.scss
@@ -9,18 +9,24 @@
     }
   }
   .has-menu {
+    order: 1;
     @include mq($md) {
       @include column-width(2, -4);
+      order: 1;
     }
   }
 
   .layout__region--menu {
     @include center-columns($grid-columns-mobile, $grid-columns-mobile);
+    order: -1;
+    margin-top: 16px;
     @include mq($ph) {
       @include center-columns($grid-columns, $grid-columns);
     }
     @include mq($md) {
       @include column-width(10, 12);
+      margin-top: 0;
+      order: 1;
     }
   }
 
@@ -246,6 +252,8 @@
       height: 16px;
       transform: rotate(90deg);
       width: 16px;
+      position: relative;
+      top: 2px;
     }
 
     @include mq($md) {

--- a/themes/custom/ts_wrin/sass/components/_simple-page.scss
+++ b/themes/custom/ts_wrin/sass/components/_simple-page.scss
@@ -302,6 +302,12 @@
     a {
       @include font-line-height(18, 24);
     }
+    ul.menu {
+      border-top: 0;
+      left: -1px;
+      width: calc(100% + 2px);
+      padding-left: 2.5rem;
+    }
   }
 
   &:hover,

--- a/themes/custom/ts_wrin/sass/components/_simple-page.scss
+++ b/themes/custom/ts_wrin/sass/components/_simple-page.scss
@@ -164,6 +164,13 @@
       height: auto;
     }
   }
+
+  .simple-page .breadcrumb {
+    display: none;
+    @include mq($md) {
+      display: block;
+    }
+  }
 }
 
 .page-hierarchies {
@@ -306,16 +313,43 @@
       border-top: 0;
       left: -1px;
       width: calc(100% + 2px);
-      padding-left: 2.5rem;
     }
   }
 
   &:hover,
   &:focus,
-  &:focus-within {
+  &:focus-within,
+  .menu-open {
     ul.menu {
       opacity: 1;
       visibility: visible;
+    }
+  }
+  &.menu-closed:hover,
+  &.menu-closed:focus,
+  &.menu-closed:focus-within,
+  .menu-closed {
+    ul.menu {
+      opacity: 0;
+      visibility: hidden;
+    }
+  }
+
+  @include mq($md) {
+    &.menu-closed:hover,
+    &.menu-closed:focus,
+    &.menu-closed:focus-within,
+    .menu-closed {
+      ul.menu {
+        opacity: 1;
+        visibility: visible;
+      }
+    }
+  }
+
+  #menu-toc > ul.menu > li > .menu-item-title {
+    @include mq($md) {
+      display: none;
     }
   }
 }

--- a/themes/custom/ts_wrin/sass/components/_toc.scss
+++ b/themes/custom/ts_wrin/sass/components/_toc.scss
@@ -54,6 +54,11 @@
 }
 
 .publication__toc {
+  display: none;
+  @include mq($md) {
+    display: block;
+  }
+
   @include font($acumin-semi-cond, "bold");
   @include font-line-height(18, 21);
   position: relative;
@@ -174,6 +179,14 @@
     .nav-arrow svg {
       width: 8px;
     }
+  }
+}
+
+.mobile__toc {
+  display: block;
+  margin-top: 16px;
+  @include mq($md) {
+    display: none;
   }
 }
 

--- a/themes/custom/ts_wrin/templates/fields/field--reset--child-pages.html.twig
+++ b/themes/custom/ts_wrin/templates/fields/field--reset--child-pages.html.twig
@@ -5,4 +5,4 @@
  */
 #}
 {{ drupal_contextual_links('menu:menu=page-hierarchies:langcode=en') }}
-{{ drupal_block('menu_block:page-hierarchies', {level: 1, depth: 0, parent: 'page-hierarchies:' ~ items[0]["content"][0]["#menu_link"], render_parent: false, follow_parent: 'child', follow: 0, label: 'Child pages', label_display: 0, id:'page-hierarchies'}) }}
+{{ drupal_block('menu_block:page-hierarchies', {level: 1, depth: 0, parent: 'page-hierarchies:' ~ items[0]["content"][0]["#menu_link"], render_parent: true, follow_parent: 'child', follow: 0, label: 'Child pages', label_display: 0, id:'page-hierarchies'}) }}


### PR DESCRIPTION
## What issue(s) does this solve?
Replace black bar submenus on mobile for project pages, tweak simple-page mobile dropdown location.

- [x] Issue Number: https://github.com/wri/WRIN/issues/462

## What is the new behavior?
 - Subpage menus on /aqueduct and /toolbox/setting-enterprise-water-targets are a dropdown on screen sizes under 48 rems.
 - The menu dropdown appears above the "About us" title on /about on mobile, and continues to be a dropdown until we hit 48rems screen size.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1212

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
