### PR TITLE
#471: hide form after event.

### DIFF
--- a/modules/wri_event/layouts/layout--event.html.twig
+++ b/modules/wri_event/layouts/layout--event.html.twig
@@ -102,7 +102,11 @@
     {% endif %}
     {% if content.main_content %}
       <div {{ region_attributes.main_content.addClass('layout__region', 'layout__region--main_content', 'main-content', 'margin-bottom-lg') }}>
+      {% if content.is_past %}
+        {{ content.main_content|without('field_zoom_registration_form') }}
+      {% else %}
         {{ content.main_content }}
+      {% endif %}
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
## What issue(s) does this solve?
Webforms show for events that are passed. 

- [x] Issue Number: https://github.com/wri/WRIN/issues/471

## What is the new behavior?
Auto-Hides event forms after events.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1220

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
