### PR TITLE
#462: add menus, submenus to microsites

### DIFF
--- a/modules/wri_publication/templates/wri-publication-columns.html.twig
+++ b/modules/wri_publication/templates/wri-publication-columns.html.twig
@@ -69,10 +69,8 @@
         </div>
       {% endif %}
       {# end if content.hero #}
-
-
-      {% if content.category or content.share %}
-        {% if display_type == 'robust' and (content.hero.field_toc is not empty) and (content.hero.field_toc['#value'] != 'microsite') %}
+      {% if content.field_toc['#value'] %}
+        {% if display_type == 'robust' and (content.hero.field_toc is not empty) %}
           <div class="mobile__toc grid">
             <div class="internal-menu-pages">
               {% set node_title = content.hero.field_toc['#node_title'] %}
@@ -86,33 +84,35 @@
                   <ul class="toc-list menu" data-toc="div.layout__region--content" data-toc-headings=".publication__main h2"></ul>
                 </nav>
               {% else %}
-                {{ drupal_block('menu_block:' ~ menu_title, {level: 1, expand_all_items: 1, depth: 0, parent: menu_title ~ ':' ~ menu_link, render_parent: 0, follow_parent: 'child', follow: 0, label: 'Table of Contents', label_display: 0, id:'page-hierarchies', suggestion: 'page-hierarchies'}) }}
+                {{ drupal_block('menu_block:' ~ menu_title, {level: 1, expand_all_items: 1, depth: 0, parent: menu_title ~ ':' ~ menu_link, render_parent: 1, follow_parent: 'child', follow: 0, label: 'Table of Contents', label_display: 0, id:'page-hierarchies', suggestion: 'page-hierarchies'}) }}
               {% endif %}
             </div>
            </div>
         {% endif %}
-        <div class="detail__meta meta grid margin-top-md margin-bottom-md">
-          <div class="detail__meta-inner meta-inner {% if content.sidebar.field_narrative_taxonomy|render %}two-column{% endif %}">
-            {% if content.category %}
-            <div {{ region_attributes.category.addClass('layout__region', 'layout__region--category') }}>
-              {{ content.category }}
-            </div>
-            {% endif %}
+        {% if content.category or content.share %}
+          <div class="detail__meta meta grid margin-top-md margin-bottom-md">
+            <div class="detail__meta-inner meta-inner {% if content.sidebar.field_narrative_taxonomy|render %}two-column{% endif %}">
+              {% if content.category %}
+              <div {{ region_attributes.category.addClass('layout__region', 'layout__region--category') }}>
+                {{ content.category }}
+              </div>
+              {% endif %}
 
-            {% if content.share %}
-            <div {{ region_attributes.share.addClass('layout__region', 'layout__region--share') }}>
-              {{ content.share }}
+              {% if content.share %}
+              <div {{ region_attributes.share.addClass('layout__region', 'layout__region--share') }}>
+                {{ content.share }}
+              </div>
+              {% endif %}
             </div>
+            {% if show_narrative_taxonomy == true %}
+              {% if content.sidebar.field_narrative_taxonomy|render %}
+                <div class="detail__meta-secondary">
+                  {{ content.sidebar.field_narrative_taxonomy }}
+                </div>
+              {% endif %}
             {% endif %}
           </div>
-          {% if show_narrative_taxonomy == true %}
-            {% if content.sidebar.field_narrative_taxonomy|render %}
-              <div class="detail__meta-secondary">
-                {{ content.sidebar.field_narrative_taxonomy }}
-              </div>
-            {% endif %}
-          {% endif %}
-        </div>
+        {% endif %}
       {% endif %}
 
       <div class="publication__main grid margin-top-lg">

--- a/modules/wri_subpage/templates/wri-subpage-columns.html.twig
+++ b/modules/wri_subpage/templates/wri-subpage-columns.html.twig
@@ -45,8 +45,8 @@
     {% endif %}
     {# end if content.hero #}
 
-    {% if content.category or content.share %}
-      {% if (content.hero.field_toc is not empty) and (content.hero.field_toc['#value'] != 'microsite') %}
+    {% if content.field_toc['#value'] %}
+      {% if (content.hero.field_toc is not empty) %}
         <div class="mobile__toc grid">
           <div class="internal-menu-pages">
             {% set node_title = content.hero.field_toc['#node_title'] %}
@@ -65,21 +65,23 @@
           </div>
          </div>
       {% endif %}
-      <div class="detail__meta meta grid margin-top-md margin-bottom-md">
-        <div class="detail__meta-inner meta-inner {% if content.sidebar.field_narrative_taxonomy|render %}two-column{% endif %}">
-          {% if content.category %}
-            <div {{ region_attributes.category.addClass('layout__region', 'layout__region--category') }}>
-              {{ content.category }}
-            </div>
-          {% endif %}
+      {% if content.category or content.share %}
+        <div class="detail__meta meta grid margin-top-md margin-bottom-md">
+          <div class="detail__meta-inner meta-inner {% if content.sidebar.field_narrative_taxonomy|render %}two-column{% endif %}">
+            {% if content.category %}
+              <div {{ region_attributes.category.addClass('layout__region', 'layout__region--category') }}>
+                {{ content.category }}
+              </div>
+            {% endif %}
 
-          {% if content.share %}
-            <div {{ region_attributes.share.addClass('layout__region', 'layout__region--share') }}>
-              {{ content.share }}
-            </div>
-          {% endif %}
+            {% if content.share %}
+              <div {{ region_attributes.share.addClass('layout__region', 'layout__region--share') }}>
+                {{ content.share }}
+              </div>
+            {% endif %}
+          </div>
         </div>
-      </div>
+      {% endif %}
     {% endif %}
   </div>
 {% endif %}

--- a/themes/custom/ts_wrin/sass/components/_simple-page.scss
+++ b/themes/custom/ts_wrin/sass/components/_simple-page.scss
@@ -257,10 +257,12 @@
       content: "";
       display: block;
       height: 16px;
-      transform: rotate(90deg);
-      width: 16px;
+      min-height: 16px;
+      min-width: 16px;
       position: relative;
       top: 2px;
+      transform: rotate(90deg);
+      width: 16px;
     }
 
     @include mq($md) {
@@ -351,5 +353,15 @@
     @include mq($md) {
       display: none;
     }
+  }
+
+  #menu-toc .menu-link-contentmicrosites {
+    position: static;
+  }
+}
+
+.view .internal-menu-pages  #menu-toc > ul.menu > li > .menu-item-title {
+  @include mq($md) {
+    display: block;
   }
 }

--- a/themes/custom/ts_wrin/templates/blocks/block--menu-block--microsites.html.twig
+++ b/themes/custom/ts_wrin/templates/blocks/block--menu-block--microsites.html.twig
@@ -6,28 +6,7 @@
  * Only show this block if it has a menu in it.
  */
 #}
-{% if content['#menu_name'] %}
-{%
-  set classes = [
-    'block',
-    'block-menu',
-    'navigation',
-    'menu--' ~ derivative_plugin_id|clean_class,
-  ]
-%}
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
-<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
-
-  {# Menu. #}
-  {% block content %}
-    {{ content }}
-  {% endblock %}
-</nav>
-{% endif %}
+<div class="internal-menu-pages">
+  <div class="field-label" tabindex="0"><a tabindex="-1" href="#">{{ "Menu"|t }}</a></div>
+  {% include '@ts_wrin/_includes/_toc.html.twig' %}
+</div>


### PR DESCRIPTION
## What issue(s) does this solve?
Replace black/gold bar submenus on mobile for project pages, tweak simple-page mobile dropdown location.

- [x] Issue Number: https://github.com/wri/WRIN/issues/462

## What is the new behavior?
 - Subpage menus on /cities and other microsites appear on screen sizes under 48 rems.
 - Fix views menus not not appearing, e.g. /about/experts-staff 
 - The menu dropdown appears above the "About us" title on /about on mobile, and continues to be a dropdown until we hit 48rems screen size.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1223

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
