### PR TITLE
#302: 'Listen on' CKEditor template for podcasts

### DIFF
--- a/modules/wri_admin/templates/ckeditor5_template.json
+++ b/modules/wri_admin/templates/ckeditor5_template.json
@@ -28,5 +28,11 @@
       "icon": "",
       "description": "",
       "html": "<div class=\"report-teaser gold-borders-medium alignright\"><div class=\"image-wrapper\">Optional Image - set to 'Thumbnail'</div><div class=\"text-wrapper\"><div class=\"h4 topic-tag\">Report/Pub Title</div><p>Teaser text for the report or publication.</p><p><a href=\"/resources\" class=\"button small\">Download</a></p></div></div>"
+    },
+    {
+      "title": "Podcast: Listen On...",
+      "icon": "",
+      "description": "",
+      "html": "<p>&nbsp;</p><p class=\"secondary\" style=\"line-height:0;\"><em>Or listen on:</em></p><div class=\"icons-container\"><div class=\"icons-div apple-podcasts-button\"><a href=\"\"><span class=\"podcast-social-icon secondary\">Apple&nbsp;Podcasts</span></a></div><div class=\"icons-div spotify-podcasts-button\"><a href=\"\"><span class=\"podcast-social-icon secondary\">Spotify</span><strong>&nbsp;</strong></a></div><div class=\"icons-div youtube-podcasts-button\"><a href=\"\"><span class=\"podcast-social-icon secondary\">YouTube</span>&nbsp;</a></div></div>"
     }
 ]

--- a/themes/custom/ts_wrin/sass/ckeditor.scss
+++ b/themes/custom/ts_wrin/sass/ckeditor.scss
@@ -40,4 +40,54 @@
     -webkit-font-smoothing: antialiased;
     color: $black;
   }
+
+  // Podcast icons.
+  .icons-container {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  .icons-container > .icons-div {
+    margin: 10px;
+    padding: 12px;
+    border: 1px solid #000;
+    width: 155px;
+    height: 25px;
+  }
+  .icons-container > .icons-div:hover {
+    background-color: #fafafa !important;
+  }
+  .icons-container > .icons-div img {
+    vertical-align: middle;
+  }
+  .icons-container a  {
+    text-decoration: none;
+    align-items: center;
+    color: #000;
+  }
+  .apple-podcasts-button {
+    background-image: url('https://files.wri.org/d8/s3fs-public/2024-07/apple-podcasts-icon.png');
+  }
+  .youtube-podcasts-button {
+    background-image: url('https://files.wri.org/d8/s3fs-public/2024-07/youtube-icon.png');
+  }
+  .spotify-podcasts-button {
+    background-image: url('https://files.wri.org/d8/s3fs-public/2024-07/spotify-icon.png');
+  }
+  .icons-div {
+    background-position: 10px 50%;
+    background-repeat: no-repeat;
+    background-size: 30px auto;
+  }
+  .podcast-social-icon {
+    margin-left: 40px;
+    font-size: 1rem;
+  }
+
+  .icons-container div a {
+    text-decoration: none !important;
+  }
+
+  .icons-div a {
+    display: block;
+  }
 }


### PR DESCRIPTION
## What issue(s) does this solve?
Adds CKEditor template for the podcast 'Listen On' icons. 

- [x] Issue Number: https://github.com/wri/wri_sites/issues/302

## What is the new behavior?
Icons! Add links in CKEditor. 

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1226

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
