### PR TITLE
#474: add field_intro to region & simple page meta

### DIFF
--- a/modules/wri_region/config/install/metatag.metatag_defaults.node__region.yml
+++ b/modules/wri_region/config/install/metatag.metatag_defaults.node__region.yml
@@ -4,6 +4,7 @@ dependencies: {  }
 id: node__region
 label: 'Content: Region'
 tags:
+  description: '[node:field_intro]'
   image_src: '[node:field_map_image:entity:field_media_image]'
   og_image: '[node:field_map_image:entity:field_media_image]'
   twitter_cards_image: '[node:field_map_image:entity:field_media_image]'

--- a/modules/wri_region/wri_region.install
+++ b/modules/wri_region/wri_region.install
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for wri_region.
+ */
+
+/**
+ * Update the metatags to display field_intro for description.
+ */
+function wri_region_update_10001() {
+  \Drupal::service('distro_helper.updates')->updateConfig('metatag.metatag_defaults.node__region', [
+    'tags#description',
+  ], 'wri_region');
+
+  $message = 'Add field_intro to metatags description';
+  return $message;
+}

--- a/modules/wri_simple_page/config/install/metatag.metatag_defaults.node__simple_page.yml
+++ b/modules/wri_simple_page/config/install/metatag.metatag_defaults.node__simple_page.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__simple_page
+label: 'Content: Simple Page'
+tags:
+  description: '[node:field_intro]'

--- a/modules/wri_simple_page/wri_simple_page.install
+++ b/modules/wri_simple_page/wri_simple_page.install
@@ -27,3 +27,13 @@ function wri_simple_page_update_dependencies() {
 
   return $dependencies;
 }
+
+/**
+ * Update the metatags to display field_intro for description.
+ */
+function wri_simple_page_update_10001() {
+  \Drupal::service('distro_helper.updates')->installConfig('metatag.metatag_defaults.node__simple_page', 'wri_simple_page', 'install', 'TRUE');
+
+  $message = 'Add field_intro to metatags description';
+  return $message;
+}


### PR DESCRIPTION
## What issue(s) does this solve?
Region and Simple pages do not have default metatag descriptions.

- [ ] Issue Number: https://github.com/wri/WRIN/issues/474

## What is the new behavior?
- `[node:field_intro]` in metatag description

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1229

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
