### PR TITLE
#1208: add update hook for full_html editor

### DIFF
--- a/modules/wri_media/config/install/editor.editor.full_html.yml
+++ b/modules/wri_media/config/install/editor.editor.full_html.yml
@@ -59,6 +59,7 @@ settings:
         - '<div class>'
         - '<span>'
         - '<a name>'
+        - '<script src>'
     ckeditor5_style:
       styles:
         -

--- a/modules/wri_media/config/install/filter.format.full_html.yml
+++ b/modules/wri_media/config/install/filter.format.full_html.yml
@@ -45,7 +45,7 @@ filters:
     status: false
     weight: -50
     settings:
-      allowed_html: '<div class> <a name class="button"> <span class="drop-cap"> <p class="secondary">'
+      allowed_html: '<div class> <a name class="button"> <script src> <span class="drop-cap"> <p class="secondary">'
       filter_html_help: false
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -90,3 +90,15 @@ function wri_media_update_10103() {
   \Drupal::service('distro_helper.updates')->installConfig('image.style.180x240_scale', 'wri_media', 'install', 'TRUE');
   \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.media.image.thumbnail', 'wri_media', 'install', 'TRUE');
 }
+
+/**
+ * Update our editors to allow script tags.
+ */
+function wri_media_update_10104() {
+  \Drupal::service('distro_helper.updates')->updateConfig('editor.editor.full_html', [
+    'settings#plugins#ckeditor5_sourceEditing#allowed_tags',
+  ], 'wri_media', 'install');
+  \Drupal::service('distro_helper.updates')->updateConfig('filter.format.full_html', [
+    'filters#filter_html#settings#allowed_html',
+  ], 'wri_media', 'install');
+}


### PR DESCRIPTION
## What issue(s) does this solve?
Adds a WRI Policy module that adds an entity and controller for sharing content with a simple JS snippet. 

- [x] Issue Number: https://github.com/wri/wriflagship/issues/1208

## What is the new behavior?
- This is just an update to the 'Full HTML' WYSIWYG fields to allow `<script src>`, everything else is in wriflagship. 

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1233

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
