### PR TITLE
Flagship issue #1245: hardcode GMT in date / times

### DIFF
--- a/modules/wri_event/config/install/asset_injector.css.address_honeypot_field.yml
+++ b/modules/wri_event/config/install/asset_injector.css.address_honeypot_field.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: address_honeypot_field
+label: 'Address Honeypot Field'
+code: |-
+  .form-item-address {
+  	display: none;
+  }
+media: all
+preprocess: true
+conditions:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      event: event
+contexts: {  }
+conditions_require_all: true

--- a/modules/wri_event/config/install/smart_date.smart_date_format.compact_dot.yml
+++ b/modules/wri_event/config/install/smart_date.smart_date_format.compact_dot.yml
@@ -4,8 +4,8 @@ dependencies: {  }
 id: compact_dot
 label: 'Compact dot'
 date_format: 'F d, Y'
-time_format: 'g:ia T'
-time_hour_format: 'g:ia T'
+time_format: 'g:ia <\s\p\a\n \c\l\a\s\s=''\g\m\t''>T</\s\p\a\n>'
+time_hour_format: 'g:ia <\s\p\a\n \c\l\a\s\s=''\g\m\t''>T</\s\p\a\n>'
 allday_label: 'All day'
 separator: ' - '
 join: '<span>•</span>'

--- a/modules/wri_event/wri_event.install
+++ b/modules/wri_event/wri_event.install
@@ -142,3 +142,58 @@ function wri_event_update_10003() {
     ]);
   }
 }
+
+/**
+ * Update Smart Date compact_dot time_format and update the asset injectors.
+ */
+function wri_event_update_10004() {
+  \Drupal::service('distro_helper.updates')->updateConfig('smart_date.smart_date_format.compact_dot', [
+    'time_format', 'time_hour_format',
+  ], 'wri_event');
+
+  \Drupal::service('distro_helper.updates')->updateConfig('asset_injector.css.address_honeypot_field', [
+    'code',
+  ], 'wri_event');
+
+  // Load the configuration.
+  $config_name = 'asset_injector.js.add_gmt_to_events';
+
+  // Define the file path to the configuration file in the project root /config/
+  // directory.
+  $config_file_path = dirname(DRUPAL_ROOT) . '/config/asset_injector.js.add_gmt_to_events.yml';
+
+  // Check if the configuration exists in the active store.
+  if (\Drupal::configFactory()->getEditable($config_name)->isNew() === FALSE) {
+    // Delete the configuration from active storage.
+    \Drupal::configFactory()->getEditable($config_name)->delete();
+
+    \Drupal::logger('wri_event')->notice('Configuration %config_name was successfully deleted from active storage.', [
+      '%config_name' => $config_name,
+    ]);
+
+    // Check if the config file exists in the /config/ directory.
+    if (file_exists($config_file_path)) {
+      // Attempt to delete the file.
+      if (unlink($config_file_path)) {
+        \Drupal::logger('wri_event')->notice('Configuration file %file_path was successfully deleted from the config directory.', [
+          '%file_path' => $config_file_path,
+        ]);
+      }
+      else {
+        \Drupal::logger('wri_event')->error('Failed to delete configuration file %file_path.', [
+          '%file_path' => $config_file_path,
+        ]);
+      }
+    }
+    else {
+      \Drupal::logger('wri_event')->warning('Configuration file %file_path not found in the config directory.', [
+        '%file_path' => $config_file_path,
+      ]);
+    }
+  }
+  else {
+    \Drupal::logger('wri_event')->warning('Configuration %config_name not found in active storage.', [
+      '%config_name' => $config_name,
+    ]);
+  }
+}

--- a/themes/custom/ts_wrin/js/components/wri_datetime.js
+++ b/themes/custom/ts_wrin/js/components/wri_datetime.js
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * WRI Datetime js.
+ */
+export default function(context) {
+  const $ = jQuery;
+
+  $('span.gmt').once().each(function(e) {
+    var gmt_text = $(this).text().trim();
+      if (!gmt_text) {
+        $(this).addClass('hidden');
+      } else if (gmt_text.startsWith('-') || gmt_text.startsWith('+')) {
+        $(this).prepend('GMT');
+      }
+  });
+}

--- a/themes/custom/ts_wrin/js/main.js
+++ b/themes/custom/ts_wrin/js/main.js
@@ -14,6 +14,7 @@ import wriMoreOn from "./components/wri_more_on.js";
 import wriMedia from "./components/wri_media.js";
 import wriCtaBanners from "./components/wri_cta_banners.js";
 import tsExternalLinks from "./components/ts_external_links.js";
+import wriDatetime from "./components/wri_datetime.js";
 
 (($, Drupal) => {
   /**
@@ -65,5 +66,9 @@ import tsExternalLinks from "./components/ts_external_links.js";
 
   Drupal.behaviors.tsExternalLinks = {
     attach: tsExternalLinks
+  };
+
+  Drupal.behaviors.wriDatetime = {
+    attach: wriDatetime
   };
 })(jQuery, Drupal);

--- a/themes/custom/ts_wrin/sass/components/_events.scss
+++ b/themes/custom/ts_wrin/sass/components/_events.scss
@@ -131,6 +131,10 @@
       &.event-info-date span {
         padding: 0 15px;
       }
+      &.event-info-date span.gmt {
+        margin: 0;
+        padding: 0;
+      }
 
       @include mq($lg) {
         display: inline-block;


### PR DESCRIPTION
## What issue(s) does this solve?
- Reformats to GMT offset the prepend 'GMT' when there's a value
- Updates / removes asset injectors as needed

Issue: https://github.com/wri/wriflagship/issues/1245

## What is the new behavior?
Moves the fix from asset injector(s) to config/code.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1251

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
