### PR TITLE
WRI-Espanol Issue  #27 - trim length of link

### DIFF
--- a/modules/wri_homepage/config/install/core.entity_view_display.paragraph.featured_statement.preview.yml
+++ b/modules/wri_homepage/config/install/core.entity_view_display.paragraph.featured_statement.preview.yml
@@ -1,4 +1,3 @@
-langcode: es
 status: true
 dependencies:
   config:

--- a/modules/wri_homepage/config/install/core.entity_view_display.paragraph.featured_statement.preview.yml
+++ b/modules/wri_homepage/config/install/core.entity_view_display.paragraph.featured_statement.preview.yml
@@ -1,0 +1,93 @@
+langcode: es
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.preview
+    - field.field.paragraph.featured_statement.field_link
+    - field.field.paragraph.featured_statement.field_text
+    - field.field.paragraph.featured_statement.field_title
+    - field.field.paragraph.featured_statement.field_updated
+    - paragraphs.paragraphs_type.featured_statement
+  module:
+    - ds
+    - layout_builder
+    - link
+third_party_settings:
+  layout_builder:
+    enabled: false
+    allow_custom: false
+id: paragraph.featured_statement.preview
+targetEntityType: paragraph
+bundle: featured_statement
+mode: preview
+content:
+  field_link:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 20
+      url_only: true
+      url_plain: true
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 3
+    region: content
+  field_text:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings:
+      ds:
+        ft:
+          id: minimal
+          settings:
+            lb: ''
+            lb-col: false
+            classes: {  }
+    weight: 2
+    region: content
+  field_title:
+    type: string
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings:
+      ds:
+        ft:
+          id: minimal
+          settings:
+            lb: ''
+            lb-col: false
+            classes: {  }
+    weight: 1
+    region: content
+  field_updated:
+    type: timestamp
+    label: hidden
+    settings:
+      date_format: custom
+      custom_date_format: 'F d, Y'
+      timezone: ''
+      tooltip:
+        date_format: ''
+        custom_date_format: ''
+      time_diff:
+        enabled: false
+        future_format: '@interval hence'
+        past_format: '@interval ago'
+        granularity: 2
+        refresh: 60
+    third_party_settings:
+      ds:
+        ft:
+          id: minimal
+          settings:
+            lb: ''
+            lb-col: false
+            classes: {  }
+    weight: 0
+    region: content
+hidden:
+  search_api_excerpt: true

--- a/modules/wri_homepage/wri_homepage.install
+++ b/modules/wri_homepage/wri_homepage.install
@@ -27,3 +27,15 @@ function wri_homepage_update_dependencies() {
 
   return $dependencies;
 }
+
+
+/**
+ * Update the Featured Statement paragraph to have a preview mode.
+ */
+function wri_homepage_update_10001() {
+
+  \Drupal::service('distro_helper.updates')->installConfig('core.entity_view_display.paragraph.featured_statement.preview', 'wri_homepage', 'install', 'TRUE');
+
+  $message = 'Add Preview mode for Featured Statement paragraph';
+  return $message;
+}


### PR DESCRIPTION
## What issue(s) does this solve?
Can't see the edit button for the Featured Preview paragraph b/c the string is too long. 

- Issue Number: https://github.com/wri/wri-espanol/issues/27

## What is the new behavior?
Adds a preview mode to the 'Featured Paragraph' so the link field can be trimmed in admin.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/1252

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
