### PR TITLE
#472: more double-quote adjustments

### DIFF
--- a/modules/wri_media/config/install/editor.editor.full_html.yml
+++ b/modules/wri_media/config/install/editor.editor.full_html.yml
@@ -73,6 +73,9 @@ settings:
         -
           label: 'Quote Mark'
           element: '<p class="with-quote">'
+        -
+          label: 'Attribution'
+          element: '<span class="attribution">'
     ckeditor5_template_template:
       file_path: /profiles/contrib/wri_sites/modules/wri_admin/templates/ckeditor5_template.json
       custom_toolbar_text: Template

--- a/modules/wri_media/config/install/filter.format.full_html.yml
+++ b/modules/wri_media/config/install/filter.format.full_html.yml
@@ -45,7 +45,7 @@ filters:
     status: false
     weight: -50
     settings:
-      allowed_html: '<div class> <a name class="button"> <span class="drop-cap"> <p class="secondary with-quote">'
+      allowed_html: '<div class> <a name class="button"> <span class="drop-cap attribution"> <p class="secondary with-quote">'
       filter_html_help: false
       filter_html_nofollow: false
   filter_html_escape:

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -103,6 +103,7 @@ function wri_media_update_10104() {
     'settings#plugins#ckeditor5_style#styles',
   ], 'wri_media');
 }
+
 /**
  * Update filter blockquote settings.
  */

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -103,3 +103,14 @@ function wri_media_update_10104() {
     'settings#plugins#ckeditor5_style#styles',
   ], 'wri_media');
 }
+/**
+ * Update filter blockquote settings.
+ */
+function wri_media_update_10105() {
+  \Drupal::service('distro_helper.updates')->updateConfig('filter.format.full_html', [
+    'filters#filter_html#settings#allowed_html',
+  ], 'wri_media');
+  \Drupal::service('distro_helper.updates')->updateConfig('editor.editor.full_html', [
+    'settings#plugins#ckeditor5_style#styles',
+  ], 'wri_media');
+}

--- a/themes/custom/ts_wrin/sass/ckeditor.scss
+++ b/themes/custom/ts_wrin/sass/ckeditor.scss
@@ -29,7 +29,7 @@
     margin-left: 0;
   }
 
-  blockquote:before {
+  blockquote p.with-quote:before {
     content: none;
   }
 

--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -192,13 +192,17 @@ blockquote {
     &:first-of-type {
       margin-top: 0;
     }
+
+    &.with-quote {
+      text-indent: rem(16);
+    }
+
     &.with-quote:before {
       @include font($caslon, "bold");
       content: "“";
       font-size: 58px;
       position: absolute;
-      top: -21px;
-      left: 0px;
+      left: 0;
     }
     span.attribution {
       @include font($acumin-semi-cond, "semibold");

--- a/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
+++ b/themes/custom/ts_wrin/sass/global/_wysiwyg.scss
@@ -168,7 +168,7 @@ blockquote {
   padding: 0;
 
   p {
-    @include font($acumin-semi-cond, "bold");
+    @include font($acumin-semi-cond, "medium");
     @include font-line-height(20, 28);
     border-left: 1px solid #b1b1b1;
     margin: 16px 0;
@@ -193,12 +193,19 @@ blockquote {
       margin-top: 0;
     }
     &.with-quote:before {
-      content: "‘";
-      font-size: 60px;
-      font-weight: 700;
+      @include font($caslon, "bold");
+      content: "“";
+      font-size: 58px;
       position: absolute;
-      top: -16px;
-      left: 8px;
+      top: -21px;
+      left: 0px;
+    }
+    span.attribution {
+      @include font($acumin-semi-cond, "semibold");
+      @include font-line-height(18, 28);
+      @include mq($md) {
+        @include font-line-height(22, 32);
+      }
     }
   }
 


### PR DESCRIPTION
## What issue(s) does this solve?
More fine-tuning of the blockquote.

- Issue Number: https://github.com/wri/WRIN/issues/472

## What is the new behavior?
- Double quote instead of single, in Caslon Pro (serif)
- Attribution property (another style)

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/1253

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
