### PR TITLE
Fix for WSOD - check intermediate objects, etc.

### DIFF
--- a/modules/wri_narrative/wri_narrative.module
+++ b/modules/wri_narrative/wri_narrative.module
@@ -28,7 +28,16 @@ function wri_narrative_preprocess_wri_narrative_tax(&$context) {
     // from landing page node.
     if ($current_filter) {
       $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($current_filter);
-      $landing_narrative_tax = $term->get('field_landing_page')->entity->get('field_narrative_taxonomy')->view(['label' => 'hidden']);
+      $landing_narrative_tax = NULL;
+
+      if ($term->hasField('field_landing_page') && !$term->get('field_landing_page')->isEmpty()) {
+        $landing_page_entity = $term->get('field_landing_page')->entity;
+
+        if ($landing_page_entity && $landing_page_entity->hasField('field_narrative_taxonomy') && !$landing_page_entity->get('field_narrative_taxonomy')->isEmpty()) {
+          $landing_narrative_tax = $landing_page_entity->get('field_narrative_taxonomy')->view(['label' => 'hidden']);
+        }
+      }
+
       $context["content"]["phrase"] = $landing_narrative_tax;
     }
   }


### PR DESCRIPTION
## What issue(s) does this solve?
Fixes site error when the 'cities' filter is applied.

- [x] Issue Number: - https://github.com/wri/WRIN/issues/495

## What is the new behavior?
 - `field_landing_page` might not exist on $term
 - `->entity` might be null if `field_landing_page` is empty or not referencing a valid entity
 - `field_narrative_taxonomy` might not exist on the entity referenced by `field_landing_page`. 

Added a set of checks for all possibilities and it's working as expected. 

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1266

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
