### PR TITLE
PR - Allow metatags to show up in views

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
                 "Contextual links for translation are removed by core https://www.drupal.org/project/layout_builder_st/issues/3411037": "https://git.drupalcode.org/project/layout_builder_st/-/merge_requests/5.diff",
                 "Drupal\\Component\\Plugin\\Exception\\PluginNotFoundException: The \"block.settings.<block_name>\" plugin does not exist https://www.drupal.org/project/layout_builder_st/issues/3463435": "https://www.drupal.org/files/issues/2024-07-23/layout_builder_st-plugin-not-found-3463435-3.patch"
             },
+            "drupal/metatag": {
+                "Provide field formatter to output meta tags on-page, e.g. for use with Views (D9), https://www.drupal.org/project/metatag/issues/3027873": "https://www.drupal.org/files/issues/2023-07-23/metatag-field_formatter_for_views-3027873-27.patch"
+            },
             "drupal/paragraphs": {
                 "Paragraph access check using incorrect revision of its parent https://www.drupal.org/project/paragraphs/issues/3090200": "https://www.drupal.org/files/issues/2022-10-26/3084934-13_combine_3090200-22.patch"
             },


### PR DESCRIPTION


## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [x] Issue Number: #360

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Individual metatags can now be added to views

![Screenshot 2025-03-24 at 12 15 28 PM](https://github.com/user-attachments/assets/c246a24c-67be-45ca-be1c-9cc89fdb76dd)

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
