### PR TITLE
Updating check for new tags script

### DIFF
--- a/.ci/check-for-new-tag.sh
+++ b/.ci/check-for-new-tag.sh
@@ -15,7 +15,7 @@ ltag_commit=$(git rev-list -n 1 "$latest_tag")
 # if latest tag is a descendant of the latest tag commit, return pass
 if [ $(git merge-base --is-ancestor "$ltag_commit" "$latest_commit") 0 ]; then
   echo "New tags found. Running pre-deploy.sh"
-  ./.ci/pre-deploy.sh
+  source "$script_path/.ci/pre-deploy.sh"
 else
   echo "No new tags found."
 fi


### PR DESCRIPTION
Adding a better way to designate path of the pre-deploy script.

## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: [#387](https://github.com/wri/wriflagship/pull/1308)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
