### PR TITLE
WRIN #518: Add HorizontalBarMenuBlock.php

### DIFF
--- a/modules/wri_custom_page/config/install/node.type.custom_page.yml
+++ b/modules/wri_custom_page/config/install/node.type.custom_page.yml
@@ -5,8 +5,9 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus: {  }
-    parent: ''
+    available_menus:
+      - page-hierarchies
+    parent: 'page-hierarchies:'
 name: 'Custom Page'
 type: custom_page
 description: null

--- a/modules/wri_custom_page/wri_custom_page.install
+++ b/modules/wri_custom_page/wri_custom_page.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for wri_custom_page.
+ */
+
+/**
+ * Enables the Page Heirarchy menu on custom pages.
+ */
+function wri_custom_page_update_10400() {
+  \Drupal::service('distro_helper.updates')->updateConfig('node.type.custom_page', [
+    'third_party_settings',
+  ], 'wri_custom_page', 'install');
+}

--- a/modules/wri_menus/src/Plugin/Block/ParentMenuBlock.php
+++ b/modules/wri_menus/src/Plugin/Block/ParentMenuBlock.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "parent_menu_block",
  *   admin_label = @Translation("Menu block (show parent)"),
  *   category = @Translation("Menus"),
- *   deriver = "Drupal\menu_block\Plugin\Derivative\MenuBlock",
+ *   deriver = "Drupal\wri_menus\Plugin\Derivative\MenuBlock",
  *   forms = {
  *     "settings_tray" = "\Drupal\system\Form\SystemMenuOffCanvasForm",
  *   },

--- a/modules/wri_menus/src/Plugin/Block/ParentMenuBlock.php
+++ b/modules/wri_menus/src/Plugin/Block/ParentMenuBlock.php
@@ -48,7 +48,36 @@ class ParentMenuBlock extends OriginalMenuBlock {
       '#description' => $this->t('If the <strong>Initial visibility level</strong> is greater than 1, or a <strong>Fixed parent item</strong> is chosen, only the children of that item will be displayed by default. Enable this option to <strong>always</strong> render the parent item in the menu.'),
     ];
 
+    $form['advanced']['add_class'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('<strong>Add class to parent item</strong>'),
+      '#default_value' => $config['add_class'],
+      '#description' => $this->t('Add a class to the parent item. This is useful for styling purposes. The class mobile__toc will make this menu only show on mobile screen sizes.'),
+    ];
+
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    parent::blockSubmit($form, $form_state);
+    $this->configuration['add_class'] = $form_state->getValue('add_class');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = parent::build();
+
+    // Wrap the menu in a div with a class if specified.
+    if (isset($this->configuration['add_class'])) {
+      $build['#prefix'] = '<div class="' . $this->configuration['add_class'] . '">';
+      $build['#suffix'] = '</div>';
+    }
+    return $build;
   }
 
 }

--- a/modules/wri_menus/src/Plugin/Derivative/MenuBlock.php
+++ b/modules/wri_menus/src/Plugin/Derivative/MenuBlock.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\wri_menus\Plugin\Derivative;
+
+use Drupal\system\Plugin\Derivative\SystemMenuBlock;
+
+/**
+ * Provides block plugin definitions for custom menus.
+ *
+ * @see \Drupal\system\Plugin\Block\SystemMenuBlock
+ */
+class MenuBlock extends SystemMenuBlock {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    foreach ($this->menuStorage->loadMultiple() as $menu => $entity) {
+      $this->derivatives[$menu] = $base_plugin_definition;
+      $this->derivatives[$menu]['admin_label'] = 'WRI ' . $entity->label();
+      $this->derivatives[$menu]['config_dependencies']['config'] = [$entity->getConfigDependencyName()];
+    }
+    return $this->derivatives;
+  }
+
+}

--- a/modules/wri_toc/config/schema/wri_toc.schema.yml
+++ b/modules/wri_toc/config/schema/wri_toc.schema.yml
@@ -1,0 +1,7 @@
+block.settings.wri_toc_horizontal_bar_menu:
+  type: block_settings
+  label: 'Horizontal bar menu block'
+  mapping:
+    example:
+      type: string
+      label: Example

--- a/modules/wri_toc/config/schema/wri_toc.schema.yml
+++ b/modules/wri_toc/config/schema/wri_toc.schema.yml
@@ -2,6 +2,11 @@ block.settings.wri_toc_horizontal_bar_menu:
   type: block_settings
   label: 'Horizontal bar menu block'
   mapping:
-    example:
+    color_class:
       type: string
-      label: Example
+      label: Color Class
+      description: 'Background color class to apply (can take any css class). Example: black-bar, teal-bar'
+    menu:
+      type: string
+      label: Menu
+      description: 'The dash-case name of the menu: i.e., page-hierarchies'

--- a/modules/wri_toc/src/Plugin/Block/HorizontalBarMenuBlock.php
+++ b/modules/wri_toc/src/Plugin/Block/HorizontalBarMenuBlock.php
@@ -95,7 +95,14 @@ final class HorizontalBarMenuBlock extends BlockBase implements ContainerFactory
       $node_id = $node->id();
       $links = $this->linkManager->loadLinksByRoute('entity.node.canonical', ['node' => $node_id], $menu);
       if (!empty($links)) {
-        $menu_link = array_key_first($links);
+        $menu_link = current($links);
+        $parent = $menu_link->getParent();
+        if ($parent)  {
+          $menu_link_id = $parent;
+        }
+        else {
+          $menu_link_id = $menu_link->getPluginId();
+        }
       }
     }
 
@@ -103,7 +110,7 @@ final class HorizontalBarMenuBlock extends BlockBase implements ContainerFactory
       '#theme' => 'table_of_contents',
       '#menu_title' => $menu,
       '#value' => 'menu',
-      '#menu_link' => $menu_link,
+      '#menu_link' => $menu_link_id,
       '#node_title' => $node_title,
       '#color_bar' => $color_class,
     ];

--- a/modules/wri_toc/src/Plugin/Block/HorizontalBarMenuBlock.php
+++ b/modules/wri_toc/src/Plugin/Block/HorizontalBarMenuBlock.php
@@ -97,7 +97,7 @@ final class HorizontalBarMenuBlock extends BlockBase implements ContainerFactory
       if (!empty($links)) {
         $menu_link = current($links);
         $parent = $menu_link->getParent();
-        if ($parent)  {
+        if ($parent) {
           $menu_link_id = $parent;
         }
         else {

--- a/modules/wri_toc/src/Plugin/Block/HorizontalBarMenuBlock.php
+++ b/modules/wri_toc/src/Plugin/Block/HorizontalBarMenuBlock.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\wri_toc\Plugin\Block;
+
+use Drupal\node\NodeInterface;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Menu\MenuLinkManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\wri_toc\Traits\TocConfigTrait;
+
+/**
+ * Provides a horizontal bar menu block.
+ *
+ * @Block(
+ *   id = "wri_toc_horizontal_bar_menu",
+ *   admin_label = @Translation("Horizontal bar menu"),
+ *   category = @Translation("Custom"),
+ * )
+ */
+final class HorizontalBarMenuBlock extends BlockBase implements ContainerFactoryPluginInterface {
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * The menu link manager.
+   *
+   * @var \Drupal\Core\Menu\MenuLinkManagerInterface
+   */
+  protected $linkManager;
+
+  use TocConfigTrait;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $route_match, MenuLinkManagerInterface $link_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+    $this->linkManager = $link_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('plugin.manager.menu.link')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration(): array {
+    return $this->getDefaultTocConfig();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state): array {
+    return $this->buildTocForm($form, $form_state, $this->configuration);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state): void {
+    $this->configuration['menu'] = $form_state->getValue('menu');
+    $this->configuration['color_class'] = $form_state->getValue('color_class');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(): array {
+    $menu = $this->configuration['menu'] ?? 'page-hierarchies';
+    $color_class = $this->configuration['color_class'] ?? 'black-bar';
+    $menu_link = '';
+    $node_title = '';
+
+    $node = $this->routeMatch->getParameter('node');
+    if ($node instanceof NodeInterface) {
+      $node_title = $node->getTitle();
+      $node_id = $node->id();
+      $links = $this->linkManager->loadLinksByRoute('entity.node.canonical', ['node' => $node_id], $menu);
+      if (!empty($links)) {
+        $menu_link = array_key_first($links);
+      }
+    }
+
+    return [
+      '#theme' => 'table_of_contents',
+      '#menu_title' => $menu,
+      '#value' => 'menu',
+      '#menu_link' => $menu_link,
+      '#node_title' => $node_title,
+      '#color_bar' => $color_class,
+    ];
+  }
+
+}

--- a/modules/wri_toc/src/Plugin/Field/FieldFormatter/TableofcontentsFormatter.php
+++ b/modules/wri_toc/src/Plugin/Field/FieldFormatter/TableofcontentsFormatter.php
@@ -11,6 +11,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\wri_toc\Traits\TocConfigTrait;
 
 /**
  * Plugin implementation of the 'TableOfContents' formatter.
@@ -37,6 +38,8 @@ class TableofcontentsFormatter extends FormatterBase implements ContainerFactory
    * @var \Drupal\Core\Menu\MenuLinkManagerInterface
    */
   protected $linkManager;
+
+  use TocConfigTrait;
 
   /**
    * {@inheritdoc}
@@ -67,32 +70,15 @@ class TableofcontentsFormatter extends FormatterBase implements ContainerFactory
   /**
    * {@inheritdoc}
    */
-  public static function defaultSettings() {
-    return [
-      'menu' => 'page-hierarchies',
-      'color_class' => 'black-bar',
-    ] + parent::defaultSettings();
+  public function defaultConfiguration(): array {
+    return $this->getDefaultTocConfig();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function settingsForm(array $form, FormStateInterface $form_state) {
-
-    $elements['menu'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Menu name'),
-      '#description' => $this->t('The dash-case name of the menu: ie page-hierarchies'),
-      '#default_value' => $this->getSetting('menu') ?? 'page-hierarchies',
-    ];
-    $elements['color_class'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Color class'),
-      '#description' => $this->t('The background color class to apply. Example: black-bar, teal-bar'),
-      '#default_value' => $this->getSetting('color_class') ?? 'black-bar',
-    ];
-
-    return $elements;
+  public function blockForm($form, FormStateInterface $form_state): array {
+    return $this->buildTocForm($form, $form_state, $this->configuration);
   }
 
   /**

--- a/modules/wri_toc/src/Traits/TocConfigTrait.php
+++ b/modules/wri_toc/src/Traits/TocConfigTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\wri_toc\Traits;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides shared config form methods for TOC-style blocks and formatters.
+ */
+trait TocConfigTrait {
+
+  /**
+   * Returns default configuration values.
+   */
+  protected function getDefaultTocConfig(): array {
+    return [
+      'menu' => 'page-hierarchies',
+      'color_class' => 'black-bar',
+    ];
+  }
+
+  /**
+   * Builds the shared TOC form elements.
+   */
+  protected function buildTocForm(array $form, FormStateInterface $form_state, array $config): array {
+    $form['menu'] = [
+      '#type' => 'textfield',
+      '#title' => t('Menu name'),
+      '#description' => t('The dash-case name of the menu: i.e., page-hierarchies'),
+      '#default_value' => $config['menu'] ?? 'page-hierarchies',
+    ];
+    $form['color_class'] = [
+      '#type' => 'textfield',
+      '#title' => t('Color class'),
+      '#description' => t('Background color class to apply. Example: black-bar, teal-bar'),
+      '#default_value' => $config['color_class'] ?? 'black-bar',
+    ];
+    return $form;
+  }
+
+}

--- a/themes/custom/ts_wrin/sass/components/_simple-page.scss
+++ b/themes/custom/ts_wrin/sass/components/_simple-page.scss
@@ -192,7 +192,8 @@
 }
 
 .page-hierarchies,
-.menu-blockpage-hierarchies {
+.menu-blockpage-hierarchies,
+.parent-menu-blockpage-hierarchies {
   @include font($acumin-pro, "regular");
 
   @include mq($md) {

--- a/themes/custom/ts_wrin/templates/blocks/block--parent-menu-block--page-hierarchies.html.twig
+++ b/themes/custom/ts_wrin/templates/blocks/block--parent-menu-block--page-hierarchies.html.twig
@@ -1,0 +1,7 @@
+{#
+/**
+ * @file
+ * Theme override for the parent heirarchy menu.
+ */
+#}
+{% include '@ts_wrin/blocks/block--menu-block--page-hierarchies.html.twig' %}


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [x] Issue Number: [Page Hierarchy menu block updates. #518](https://github.com/wri/WRIN/issues/518)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Adds a 'WRI' page hierarchy menu
- Makes it available as a horizontal menu

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1309

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
