### PR TITLE
Create admin form and settings override capability for orto integration

### DIFF
--- a/modules/wri_admin/config/install/content_snippets.items.yml
+++ b/modules/wri_admin/config/install/content_snippets.items.yml
@@ -46,14 +46,6 @@ osano_params:
   description: 'Optional parameters for the Osano script (e.g. ?variant=five)'
   group: '3rd Party'
   weight: '10'
-orto_registration_url:
-  label: 'Orto Registration URL'
-  id: orto_registration_url
-  type: textarea
-  filter: full_html
-  description: '1 hour after the scheduled end time of an event with a zoom webinar ID, send the event to this url. Example: https://ortto.wri.org/zoom/import-participants/?webinarId=[WEBINARID]&webinarName=[WEBINAR_NAME]&webinarDate=[WEBINAR_DATE]. This field accepts tokens.'
-  group: '3rd Party'
-  weight: '10'
 analytics_url:
   label: 'Analytics URL'
   id: analytics_url

--- a/modules/wri_event/wri_event.install
+++ b/modules/wri_event/wri_event.install
@@ -77,12 +77,6 @@ function wri_event_update_10001() {
     'content#field_register',
   ], 'wri_event');
 
-  // Import the content_snippets:
-  \Drupal::service('distro_helper.updates')->updateConfig('content_snippets.content', ['snippets#orto_registration_url'], 'wri_listing_block');
-  \Drupal::service('distro_helper.updates')->updateConfig('content_snippets.items', [
-    'orto_registration_url',
-  ], 'wri_admin');
-
   $message = 'Added Zoom tie-in fields, webform, and settings.';
   return $message;
 }

--- a/modules/wri_listing_block/config/install/content_snippets.content.yml
+++ b/modules/wri_listing_block/config/install/content_snippets.content.yml
@@ -5,5 +5,4 @@ snippets:
   3_1_view_arguments: '[block_content:field_custom_results:array:target_id:join:+]/[block_content:field_content_types:array:target_id:join:+]/[block_content:field_filter_by_region:target_id]/[block_content:field_filter_by_resource_type:array:target_id:join:+]/[block_content:field_tag:target_id]/[block_content:field_filter_by_tag:target_id]'
   osano_id: ''
   osano_params: ''
-  orto_registration_url: 'https://ortto.wri.org/zoom/import-participants/?webinarId=[node:field_zoom_webinar_id]&webinarName=[node:title]&webinarDate=[node:field_date_time:format:default]'
   analytics_url: 'https://www.googletagmanager.com'

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -48,8 +48,8 @@ class AdminSettingsForm extends ConfigFormBase {
     global $config;
     if (isset($config['wri_zoom.settings']['orto_enabled'])) {
       $form['orto_enabled']['#title'] .= ' <i>' . $this->t('[NOTE: Overridden in settings.php to "%value"]', [
-        '%value' => $config['wri_zoom.settings']['orto_enabled'] ? 'TRUE' : 'FALSE'
-        ]) . '</i>';
+        '%value' => $config['wri_zoom.settings']['orto_enabled'] ? 'TRUE' : 'FALSE',
+      ]) . '</i>';
     }
     $form['orto_registration_url'] = [
       '#type' => 'textfield',

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -53,6 +53,8 @@ class AdminSettingsForm extends ConfigFormBase {
     }
     $form['orto_registration_url'] = [
       '#type' => 'textfield',
+      '#maxlength' => 256,
+      '#size' => 180,
       '#title' => $this->t('Orto Registration URL'),
       '#description' => $this->t("1 hour after the scheduled end time of an event with a zoom webinar ID, send the event to this url. Example: https://ortto.wri.org/zoom/import-participants/?webinarId=[WEBINARID]&webinarName=[WEBINAR_NAME]&webinarDate=[WEBINAR_DATE]. This field accepts tokens."),
       '#default_value' => $settings['orto_registration_url'] ?? '',

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -52,7 +52,7 @@ class AdminSettingsForm extends ConfigFormBase {
     }
     $form['orto_registration_url'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('Orto Registration URL	'),
+      '#title' => $this->t('Orto Registration URL'),
       '#description' => "1 hour after the scheduled end time of an event with a zoom webinar ID, send the event to this url. Example: https://ortto.wri.org/zoom/import-participants/?webinarId=[WEBINARID]&webinarName=[WEBINAR_NAME]&webinarDate=[WEBINAR_DATE]. This field accepts tokens.",
       '#default_value' => $settings['orto_registration_url'] ?? '',
     ];

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -38,21 +38,18 @@ class AdminSettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildForm($form, $form_state);
-
     $settings = $this->config(self::SETTINGS)->get();
-    // It's not clear to me how else to get the "in use" version of the
-    // configuration that accepts settings.php based changes, so we have to:
-    // @codingStandardsIgnoreStart
-    $overridden_settings = \Drupal::config(self::SETTINGS)->get();
-    // @codingStandardsIgnoreEnd
     $form['orto_enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable ORTO reporting'),
       '#description' => $this->t("If disabled, no reporting will be sent to ORTO at all. Enable only during testing or on live sites of record."),
       '#default_value' => $settings['orto_enabled'] ?? FALSE,
     ];
-    if ($settings['orto_enabled'] != $overridden_settings['orto_enabled']) {
-      $form['orto_enabled']['#title'] .= ' <i>[' . $this->t('NOTE: Overridden in settings.php') . ']</i>';
+    global $config;
+    if (isset($config['wri_zoom.settings']['orto_enabled'])) {
+      $form['orto_enabled']['#title'] .= ' <i>' . $this->t('[NOTE: Override in settings.php: %value]', [
+        '%value' => $config['wri_zoom.settings']['orto_enabled'] ? 'TRUE' : 'FALSE'
+        ]) . '</i>';
     }
     $form['orto_registration_url'] = [
       '#type' => 'textfield',

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -47,7 +47,7 @@ class AdminSettingsForm extends ConfigFormBase {
     ];
     global $config;
     if (isset($config['wri_zoom.settings']['orto_enabled'])) {
-      $form['orto_enabled']['#title'] .= ' <i>' . $this->t('[NOTE: Override in settings.php: %value]', [
+      $form['orto_enabled']['#title'] .= ' <i>' . $this->t('[NOTE: Overridden in settings.php to "%value"]', [
         '%value' => $config['wri_zoom.settings']['orto_enabled'] ? 'TRUE' : 'FALSE'
         ]) . '</i>';
     }

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\wri_zoom\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Zoom & ORTO integration settings form.
+ */
+class AdminSettingsForm extends ConfigFormBase {
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'wri_zoom.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'zoom_orto_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+
+    $settings = $this->config(self::SETTINGS)->get();
+    $overridden_settings = \Drupal::config(self::SETTINGS)->get();
+    $form['orto_enabled'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable ORTO reporting'),
+      '#description' => $this->t("If disabled, no reporting will be sent to ORTO at all. Enable only during testing or on live sites of record."),
+      '#default_value' => $settings['orto_enabled'] ?? FALSE,
+    ];
+    if ($settings['orto_enabled'] != $overridden_settings['orto_enabled']) {
+      $form['orto_enabled']['#title'] .= ' <i>[' . t('NOTE: Overridden in settings.php') . ']</i>';
+    }
+    $form['orto_registration_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Orto Registration URL	'),
+      '#description' => "1 hour after the scheduled end time of an event with a zoom webinar ID, send the event to this url. Example: https://ortto.wri.org/zoom/import-participants/?webinarId=[WEBINARID]&webinarName=[WEBINAR_NAME]&webinarDate=[WEBINAR_DATE]. This field accepts tokens.",
+      '#default_value' => $settings['orto_registration_url'] ?? '',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+    $form_state->cleanValues();
+    $values = $form_state->getValues();
+    $config = $this->config(self::SETTINGS);
+    foreach ($values as $key => $val) {
+      $config->set($key, $val);
+    }
+    $config->save();
+  }
+
+}

--- a/modules/wri_zoom/src/Form/AdminSettingsForm.php
+++ b/modules/wri_zoom/src/Form/AdminSettingsForm.php
@@ -40,7 +40,11 @@ class AdminSettingsForm extends ConfigFormBase {
     $form = parent::buildForm($form, $form_state);
 
     $settings = $this->config(self::SETTINGS)->get();
+    // It's not clear to me how else to get the "in use" version of the
+    // configuration that accepts settings.php based changes, so we have to:
+    // @codingStandardsIgnoreStart
     $overridden_settings = \Drupal::config(self::SETTINGS)->get();
+    // @codingStandardsIgnoreEnd
     $form['orto_enabled'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable ORTO reporting'),
@@ -48,12 +52,12 @@ class AdminSettingsForm extends ConfigFormBase {
       '#default_value' => $settings['orto_enabled'] ?? FALSE,
     ];
     if ($settings['orto_enabled'] != $overridden_settings['orto_enabled']) {
-      $form['orto_enabled']['#title'] .= ' <i>[' . t('NOTE: Overridden in settings.php') . ']</i>';
+      $form['orto_enabled']['#title'] .= ' <i>[' . $this->t('NOTE: Overridden in settings.php') . ']</i>';
     }
     $form['orto_registration_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Orto Registration URL'),
-      '#description' => "1 hour after the scheduled end time of an event with a zoom webinar ID, send the event to this url. Example: https://ortto.wri.org/zoom/import-participants/?webinarId=[WEBINARID]&webinarName=[WEBINAR_NAME]&webinarDate=[WEBINAR_DATE]. This field accepts tokens.",
+      '#description' => $this->t("1 hour after the scheduled end time of an event with a zoom webinar ID, send the event to this url. Example: https://ortto.wri.org/zoom/import-participants/?webinarId=[WEBINARID]&webinarName=[WEBINAR_NAME]&webinarDate=[WEBINAR_DATE]. This field accepts tokens."),
       '#default_value' => $settings['orto_registration_url'] ?? '',
     ];
 

--- a/modules/wri_zoom/wri_zoom.links.menu.yml
+++ b/modules/wri_zoom/wri_zoom.links.menu.yml
@@ -1,0 +1,6 @@
+wri_zoom.settings:
+  route_name: wri_zoom.settings
+  parent: system.admin_config_services
+  title: 'Zoom & ORTO'
+  description: 'Integration settings for Zoom & ORTO.'
+  weight: 10

--- a/modules/wri_zoom/wri_zoom.module
+++ b/modules/wri_zoom/wri_zoom.module
@@ -25,7 +25,7 @@ function wri_zoom_cron() {
   // Verify there's a configured orto_registration_url and orto is enabled.
   $settings = \Drupal::config('wri_zoom.settings');
   $orto_link = $settings->get('orto_registration_url');
-  if ($settings->get('orto_enabled') && !empty($orto_link)) {
+  if (!empty($orto_link)) {
     // Load up any event nodes without a value in field_sent_to_orto.
     $nids = \Drupal::database()->select('node', 'base_table')
       ->fields('base_table', ['nid']);
@@ -53,6 +53,11 @@ function wri_zoom_cron() {
       // Replace the orto_link tokens with node values;.
       $orto_link = \Drupal::token()->replace($orto_link, ['node' => $node]);
       // Send the node to Orto using Guzzle.
+      if (!$settings->get('orto_enabled')) {
+        \Drupal::logger('wri_zoom')
+          ->notice('Queued send to Orto for node @nid skipped because Orto sending is disabled.', ['@nid' => $node->id()]);
+        return;
+      }
       try {
         \Drupal::httpClient()->request('GET', $orto_link);
         $node->setTitle($original_title);

--- a/modules/wri_zoom/wri_zoom.module
+++ b/modules/wri_zoom/wri_zoom.module
@@ -22,11 +22,10 @@ function wri_zoom_webform_submission_insert(EntityInterface $entity) {
  * Implements hook_cron().
  */
 function wri_zoom_cron() {
-  // Verify there's a value in the content_snippet field orto_registration_url.
-  $orto_link = content_snippets_retrieve('orto_registration_url');
-
-  if (!empty($orto_link)) {
-
+  // Verify there's a configured orto_registration_url and orto is enabled.
+  $settings = \Drupal::config('wri_zoom.settings');
+  $orto_link = $settings->get('orto_registration_url');
+  if ($settings->get('orto_enabled') && !empty($orto_link)) {
     // Load up any event nodes without a value in field_sent_to_orto.
     $nids = \Drupal::database()->select('node', 'base_table')
       ->fields('base_table', ['nid']);

--- a/modules/wri_zoom/wri_zoom.post_update.php
+++ b/modules/wri_zoom/wri_zoom.post_update.php
@@ -17,4 +17,12 @@ function wri_zoom_post_update_default_admin_settings() {
     $config->set('orto_registration_url', $orto_url);
     $config->save(TRUE);
   }
+  \Drupal::service('distro_helper.updates')->updateConfig(
+    'content_snippets.content',
+    ['snippets#orto_registration_url'],
+    'wri_listing_block');
+  \Drupal::service('distro_helper.updates')->updateConfig(
+    'content_snippets.items',
+    ['orto_registration_url'],
+    'wri_admin');
 }

--- a/modules/wri_zoom/wri_zoom.post_update.php
+++ b/modules/wri_zoom/wri_zoom.post_update.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Zoom module post_update implementations.
+ */
+
+/**
+ * Transfer Orto integration settings to new configuration option.
+ */
+function wri_zoom_post_update_default_admin_settings() {
+  $orto_url = \Drupal::config('content_snippets.content')->get('snippets')['orto_registration_url'];
+  if (!empty($orto_url)) {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('wri_zoom.settings');
+    $config->set('orto_enabled', TRUE);
+    $config->set('orto_registration_url', $orto_url);
+    $config->save(TRUE);
+  }
+}

--- a/modules/wri_zoom/wri_zoom.routing.yml
+++ b/modules/wri_zoom/wri_zoom.routing.yml
@@ -1,0 +1,9 @@
+wri_zoom.settings:
+  path: '/admin/config/services/zoom'
+  defaults:
+    _form: '\Drupal\wri_zoom\Form\AdminSettingsForm'
+    _title: 'Zoom & ORTO'
+  options:
+    _admin_route: TRUE
+  requirements:
+    _permission: 'administer site configuration'


### PR DESCRIPTION
#393

flaship PR for qa: https://github.com/wri/wriflagship/pull/1318

## What issue(s) does this solve?

Sets aside ORTO integration settings (and Zoom, but there aren't any to really set that I noticed) and adds an "enabled" setting which can be easily overridden in settings.php to insulate against ORTO running in dev environments.
