### PR TITLE
wri-sites #522: remove canonical link

### DIFF
--- a/modules/wri_author/src/Entity/WRIAuthor.php
+++ b/modules/wri_author/src/Entity/WRIAuthor.php
@@ -57,7 +57,6 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     "revision_log_message" = "revision_log_message",
  *   },
  *   links = {
- *     "canonical" = "/admin/content/wri_author/{wri_author}",
  *     "add-page" = "/admin/content/wri_author/add",
  *     "add-form" = "/admin/content/wri_author/add/{wri_author_type}",
  *     "edit-form" = "/admin/content/wri_author/{wri_author}/edit",


### PR DESCRIPTION
## What issue(s) does this solve?
Google is indexing author content nodes, for example:
https://www.wri.org/admin/content/wri_author/21317

- [x] Issue Number: https://github.com/wri/WRIN/issues/522
## What is the new behavior?
`/admin/content/wri_author/21317` now throws a 404.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/1320

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
