### PR TITLE
Adding svg_image to wri_sites profile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -190,6 +190,7 @@
         "drupal/simple_popup_blocks": "^3.4",
         "drupal/simple_recaptcha": "^1.0@beta",
         "drupal/smart_date": "^4.0",
+        "drupal/svg_image": "^3.2",
         "drupal/sortableviews": "^1.0@beta",
         "drupal/token": "^1.8",
         "drupal/token_filter": "^2.1",

--- a/modules/wri_paragraph/wri_paragraph.info.yml
+++ b/modules/wri_paragraph/wri_paragraph.info.yml
@@ -5,6 +5,7 @@ core_version_requirement: '>=9.5'
 package: WRI
 dependencies:
   - paragraphs
+  - svg_image
 config_devel:
   install:
     - field.storage.paragraph.field_body

--- a/modules/wri_paragraph/wri_paragraph.install
+++ b/modules/wri_paragraph/wri_paragraph.install
@@ -64,7 +64,7 @@ function wri_paragraph_update_dependencies() {
  */
 function wri_paragraph_update_10402() {
   $moduleHandler = \Drupal::service('module_handler');
-    if ($moduleHandler->moduleExists('svg_image')) {
-      \Drupal::service('module_installer')->install(['svg_image'], TRUE);
-    }
+  if ($moduleHandler->moduleExists('svg_image')) {
+    \Drupal::service('module_installer')->install(['svg_image'], TRUE);
+  }
 }

--- a/modules/wri_paragraph/wri_paragraph.install
+++ b/modules/wri_paragraph/wri_paragraph.install
@@ -58,3 +58,13 @@ function wri_paragraph_update_dependencies() {
   ];
   return $dependencies;
 }
+
+/**
+ * Installs new module svg_image.
+ */
+function wri_paragraph_update_10402() {
+  $moduleHandler = \Drupal::service('module_handler');
+    if ($moduleHandler->moduleExists('svg_image')) {
+      \Drupal::service('module_installer')->install(['svg_image'], TRUE);
+    }
+}


### PR DESCRIPTION
## What issue(s) does this solve?


- [ ] Issue Number: #409 

## What is the new behavior?
The svg_image module has been added to the composer.json file and an install hook added to the wri_paragraphs install file.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
