### PR TITLE
QA fixes for 383

### DIFF
--- a/modules/wri_language_select/wri_language_select.module
+++ b/modules/wri_language_select/wri_language_select.module
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * WRI Language Select module file.
+ */
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function wri_language_select_preprocess_links__language_block(&$variables) {
+  // Disable links for languages that don't have translations available.
+  $node = \Drupal::routeMatch()->getParameter('node');
+  if ($node) {
+    foreach (array_keys($variables['links']) as $lang) {
+      if (!$node->hasTranslation($lang)) {
+        unset($variables['links'][$lang]);
+      }
+    }
+  }
+}

--- a/modules/wri_media/wri_media.install
+++ b/modules/wri_media/wri_media.install
@@ -123,5 +123,5 @@ function wri_media_update_10106() {
   \Drupal::service('distro_helper.updates')->installConfig('responsive_image.styles.vertical_hero', 'wri_media', 'install', 'TRUE');
   \Drupal::service('distro_helper.updates')->updateConfig('system.image.gd', [
     'jpeg_quality',
-  ], 'wri_sites');
+  ], 'wri_admin', '../../config/install');
 }

--- a/themes/custom/ts_wrin/ts_wrin.info.yml
+++ b/themes/custom/ts_wrin/ts_wrin.info.yml
@@ -22,7 +22,7 @@ regions:
   disabled: Disabled
   modals: Modals
 ckeditor5-stylesheets:
-  - ../../../../../../libraries/ts_wrin/ckeditor5.css
+  - dist/ckeditor5.css
 config_devel:
   install:
     - block.block.addressblock


### PR DESCRIPTION
## What issue(s) does this solve?
#383 contains two issue:
- CSS in the wysiwyg on admin theme
- language switcher showing untranslated links

In testing, I also discovered that new code in wri_media was breaking on the hub. This was config update code, and the issue is that `wri_sites` isn't an enabled profile on the hub, so the hub can't use it as a module argument for Distro Helper updates. Instead, we just specify a module that is present and use a workaround to locate the config files.

