### PR TITLE
Wri 380  limit layouts

### DIFF
--- a/modules/wri_custom_page/config/install/core.entity_view_display.node.custom_page.full.yml
+++ b/modules/wri_custom_page/config/install/core.entity_view_display.node.custom_page.full.yml
@@ -48,7 +48,18 @@ third_party_settings:
       - Webform
       - core
     entity_view_mode_restriction:
-      allowed_layouts: {  }
+      allowed_layouts:
+        - layout_onecol
+        - layout_twocol_section
+        - layout_threecol_section
+        - layout_fourcol_section
+        - layout_hero-and-content
+        - layout_simple-page
+        - layout_hero-5050-and-content
+        - layout_unique_feature
+        - 'single_file_component_layout:wri_page_hero'
+        - 'single_file_component_layout:wri_page_main_content'
+        - 'single_file_component_layout:wri_superfeatured'
       denylisted_blocks: {  }
       allowlisted_blocks:
         'Chaos Tools':

--- a/modules/wri_custom_page/wri_custom_page.install
+++ b/modules/wri_custom_page/wri_custom_page.install
@@ -13,3 +13,12 @@ function wri_custom_page_update_10400() {
     'third_party_settings',
   ], 'wri_custom_page', 'install');
 }
+
+/**
+ * Update layout builder options.
+ */
+function wri_custom_page_update_10401() {
+  \Drupal::service('distro_helper.updates')->updateConfig('core.entity_view_display.node.custom_page.full', [
+    'third_party_settings#layout_builder_restrictions#entity_view_mode_restriction#allowed_layouts',
+  ], 'wri_custom_page', 'install');
+}


### PR DESCRIPTION
## What issue(s) does this solve?
Limits custom layouts available to Custom Page

- [x] Issue Number: https://github.com/wri/wri_sites/issues/380
## What is the new behavior?
 - Update hook for custom_page full display mode.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [x] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/1330

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
