### PR TITLE
Logo hardcode

### DIFF
--- a/themes/custom/ts_wrin/config/install/ts_wrin.settings.yml
+++ b/themes/custom/ts_wrin/config/install/ts_wrin.settings.yml
@@ -11,3 +11,4 @@ favicon:
 white_logo:
   use_default: 0
   path: profiles/contrib/wri_sites/themes/custom/ts_wrin/img/svgs/nav_logo_white.svg
+logo_link: ''

--- a/themes/custom/ts_wrin/templates/blocks/block--ts-wrin-branding.html.twig
+++ b/themes/custom/ts_wrin/templates/blocks/block--ts-wrin-branding.html.twig
@@ -15,14 +15,14 @@
 #}
 {% block content %}
   {% if site_logo %}
-    <a href="{{ path('<front>') }}" rel="home" class="site-logo">
+    <a href="{{ logo_link }}" rel="home" class="site-logo">
       <img class="logo-white hidden" src="{{ white_logo }}" alt="{{ 'Home'|t }}" />
       <img class="logo-color" src="{{ site_logo }}" alt="{{ 'Home'|t }}" />
     </a>
   {% endif %}
   {% if site_name %}
     <div class="site-name hidden">
-      <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home">{{ site_name }}</a>
+      <a href="{{ logo_link }}" title="{{ 'Home'|t }}" rel="home">{{ site_name }}</a>
     </div>
   {% endif %}
   {% if site_slogan %}

--- a/themes/custom/ts_wrin/templates/layout/page.html.twig
+++ b/themes/custom/ts_wrin/templates/layout/page.html.twig
@@ -85,7 +85,7 @@
           <div class="container">
             <div class="footer-padding">
               <div class="footer-logo margin-bottom-md">
-                <a href="/">
+                <a href="{{  logo_link }}">
                   <img class="logo-white" src="{{ footer_logo }}" alt="{{ 'Home'|t }}" />
                 </a>
               </div>

--- a/themes/custom/ts_wrin/templates/layout/page.html.twig
+++ b/themes/custom/ts_wrin/templates/layout/page.html.twig
@@ -85,7 +85,7 @@
           <div class="container">
             <div class="footer-padding">
               <div class="footer-logo margin-bottom-md">
-                <a href="{{  logo_link }}">
+                <a href="{{ logo_link }}">
                   <img class="logo-white" src="{{ footer_logo }}" alt="{{ 'Home'|t }}" />
                 </a>
               </div>

--- a/themes/custom/ts_wrin/templates/layout/region--hamburger-nav.html.twig
+++ b/themes/custom/ts_wrin/templates/layout/region--hamburger-nav.html.twig
@@ -23,7 +23,7 @@
 
 <div {{ regionId }}{{ attributes.addClass(classes) }}>
   <div class="hamburger-header">
-    <a href="{{ path('<front>') }}" rel="home" class="site-logo">
+    <a href="{{ logo_link }}" rel="home" class="site-logo">
       <img class="logo-white" src="{{ footer_logo }}" alt="{{ 'Home'|t }}" />
     </a>
     <div class="donate-menu">{{ drupal_menu('donate') }}</div>

--- a/themes/custom/ts_wrin/templates/ts_custom/maintenance-page.html.twig
+++ b/themes/custom/ts_wrin/templates/ts_custom/maintenance-page.html.twig
@@ -50,7 +50,7 @@
         <div class="container">
           <div class="footer-padding">
             <div class="footer-logo margin-bottom-md">
-              <a href="/">
+              <a href="{{ logo_link }}">
                 {{ 'Home'|t }}
               </a>
             </div>

--- a/themes/custom/ts_wrin/theme-settings.php
+++ b/themes/custom/ts_wrin/theme-settings.php
@@ -18,6 +18,13 @@ function ts_wrin_form_system_theme_settings_alter(&$form, FormStateInterface $fo
   $form["logo"]["settings"]["logo_upload"]["#upload_validators"] = [
     'file_validate_extensions' => ['jpg jpeg gif png svg'],
   ];
+
+  $form["logo"]["settings"]['logo_link'] = [
+    '#type' => 'url',
+    '#title' => t('Link logo to an external URL'),
+    '#default_value' => theme_get_setting('logo_link', 'ts_wrin'),
+    '#description' => t('If you want the logo to link to an external site, like wri.org, enter it here. If left empty, the logo will link to the homepage of this site.'),
+  ];
   // Set up the white logo form.
   $form['white_logo'] = [
     '#type' => 'details',

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -257,6 +257,21 @@ function ts_wrin_preprocess_block(array &$variables) {
 }
 
 /**
+ * Implements hook_preprocess_block__ts_wrin_branding().
+ *
+ * Sets the logo link for the branding block.
+ */
+function ts_wrin_preprocess_block__ts_wrin_branding(array &$variables) {
+  // If the block is a branding block, set the path.
+    $logo_link = theme_get_setting('logo_link');
+    if ($logo_link) {
+      $variables['logo_link'] = $logo_link;
+    }
+    else {
+      $variables['logo_link'] = '/';
+    }
+}
+/**
  * Implements hook_theme_suggestions_block_alter().
  */
 function ts_wrin_theme_suggestions_block_alter(array &$suggestions, array $variables) {

--- a/themes/custom/ts_wrin/ts_wrin.theme
+++ b/themes/custom/ts_wrin/ts_wrin.theme
@@ -21,6 +21,13 @@ function ts_wrin_preprocess(array &$variables) {
     $variables['footer_logo'] = \Drupal::service('file_url_generator')->generateString($logo_path);
   }
   $variables['ts_wrin_path'] = \Drupal::service('extension.list.theme')->getPath('ts_wrin');
+  $logo_link = theme_get_setting('logo_link');
+  if ($logo_link) {
+    $variables['logo_link'] = $logo_link;
+  }
+  else {
+    $variables['logo_link'] = '/';
+  }
 }
 
 /**
@@ -256,21 +263,6 @@ function ts_wrin_preprocess_block(array &$variables) {
   }
 }
 
-/**
- * Implements hook_preprocess_block__ts_wrin_branding().
- *
- * Sets the logo link for the branding block.
- */
-function ts_wrin_preprocess_block__ts_wrin_branding(array &$variables) {
-  // If the block is a branding block, set the path.
-    $logo_link = theme_get_setting('logo_link');
-    if ($logo_link) {
-      $variables['logo_link'] = $logo_link;
-    }
-    else {
-      $variables['logo_link'] = '/';
-    }
-}
 /**
  * Implements hook_theme_suggestions_block_alter().
  */


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We need to link the logo on the hub site back to wri.org.

- [ ] Issue Number: https://github.com/wri/wri_sites/issues/440

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Allows you to overwrite the default "logo goes to the homepage" with a custom url
- Takes care of the header logo, as well as the ones in the footer, on the maintenance page, and in the hamburger menu (if that's enabled)
- You can overwrite the setting on the theme page at `admin/appearance/settings/ts_wrin`

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
