### PR TITLE
Simple s3 to s3 image derivative helper.

### DIFF
--- a/modules/wri_spoke/src/Plugin/EntityShareClient/Processor/S3ToS3Importer.php
+++ b/modules/wri_spoke/src/Plugin/EntityShareClient/Processor/S3ToS3Importer.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class S3ToS3Importer extends ImportProcessorPluginBase implements PluginFormInterface {
 
   /**
-   * The entity type manager.
+   * The s3fs stream wrapper.
    *
    * @var \Drupal\s3fs\StreamWrapper\S3fsStream
    */


### PR DESCRIPTION
## What issue(s) does this solve?
Adds a plugin importer to create the data in the `s3fs_file` table when you pull an s3 image to flagship.

- [ ] Issue Number: https://github.com/wri/wri_sites/issues/394

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds the importer

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1323

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
