### PR TITLE
WRIF 499: skip site-logos

### DIFF
--- a/themes/custom/ts_wrin/js/components/ts_external_links.js
+++ b/themes/custom/ts_wrin/js/components/ts_external_links.js
@@ -18,6 +18,9 @@ export default function (context) {
     const href = $this.attr("href") || "";
     const isInternal = href.indexOf(location.hostname) >= 0 && href.indexOf(location.hostname) <= 8;
 
+    // Skip .site-logo links
+    if ($this.hasClass("site-logo")) return;
+
     if (!isInternal) {
       if (!$this.attr("target")) {
         $this.attr("target", "_blank");


### PR DESCRIPTION
## What issue(s) does this solve?
Site logo from https://hub.wri.org/ to https://wri.org/ opens in new tab

- [ ] Issue Number: https://github.com/wri/wri_sites/issues/449

## What is the new behavior?
- excludes links with `site-logo`

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1340

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
