### PR TITLE
Backlink to '/events' when visiting from an admin page.

### DIFF
--- a/modules/wri_spoke/src/Path/SpokeHostProcessor.php
+++ b/modules/wri_spoke/src/Path/SpokeHostProcessor.php
@@ -32,6 +32,9 @@ class SpokeHostProcessor implements OutboundPathProcessorInterface {
   /**
    * Constructs a path processor.
    *
+   * @param \Drupal\Core\Routing\AdminContext $admin_context
+   *   The admin context service.
+   *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The Entity Type Manager.
    */

--- a/modules/wri_spoke/src/Path/SpokeHostProcessor.php
+++ b/modules/wri_spoke/src/Path/SpokeHostProcessor.php
@@ -34,7 +34,6 @@ class SpokeHostProcessor implements OutboundPathProcessorInterface {
    *
    * @param \Drupal\Core\Routing\AdminContext $admin_context
    *   The admin context service.
-   *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The Entity Type Manager.
    */
@@ -81,14 +80,8 @@ class SpokeHostProcessor implements OutboundPathProcessorInterface {
       $options['absolute'] = TRUE;
       $hub_url = parse_url($node->field_hub_canonical_url->value);
       $options['base_url'] = $hub_url['scheme'] . "://" . $hub_url['host'];
-      if ($request) {
-        if ($this->adminContext->isAdminRoute()) {
-          $uri_path = '/events';
-        }
-        else {
-          $uri_path = $request->getRequestUri();
-        }
-        $options['query']['returnTo'] = $request->getScheme() . "://" . $request->getHttpHost() . $uri_path;
+      if ($request && !$this->adminContext->isAdminRoute()) {
+        $options['query']['returnTo'] = $request->getScheme() . "://" . $request->getHttpHost() . $request->getRequestUri();
       }
       $path = $hub_url['path'];
     }

--- a/modules/wri_spoke/wri_spoke.services.yml
+++ b/modules/wri_spoke/wri_spoke.services.yml
@@ -1,6 +1,6 @@
 services:
   wri_spoke.path_outbound_host_processor:
     class: Drupal\wri_spoke\Path\SpokeHostProcessor
-    arguments: ['@entity_type.manager']
+    arguments: ['@router.admin_context', '@entity_type.manager']
     tags:
       - { name: path_processor_outbound, priority: 3000 }


### PR DESCRIPTION
## What issue(s) does this solve?
Address https://github.com/wri/WRIN/issues/535 -- changes backlinks from events to use "/events" when originating from an admin page.

@maria-thinkshout do you think this addresses the concern properly? Also, should we make that string configurable? I don't like hard-coding "/events" this way. Easy enough to convert to a snippet -- or we could get fancy and have an "events page indicator" field or something on nodes.