### PR TITLE
Populate registration field on hub-generated events. #534

### DIFF
--- a/modules/wri_spoke/wri_spoke.module
+++ b/modules/wri_spoke/wri_spoke.module
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\entity_share_client\Service\StateInformationInterface;
 
 /**
@@ -80,5 +81,18 @@ function wri_spoke_cron() {
     $settings->set('changed_since', $sync_from_time);
     $settings->save();
   }
+}
 
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function wri_spoke_node_presave(EntityInterface $entity) {
+  // Populate a default value for the "register" field on hub-supplied events
+  // so they get a nice register button.
+  if ($entity->bundle() == 'event'
+    && $entity->hasField('field_hub_canonical_url')
+    && !empty($entity->field_hub_canonical_url[0])
+    && empty($entity->field_register->getValue())) {
+    $entity->field_register->setValue(['uri' => $entity->field_hub_canonical_url->getValue()[0]['value'] . '#register']);
+  }
 }


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/WRIN/issues/534

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Populate a default value for the "register" field on hub-supplied events so they get a nice register button.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1343

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
