### PR TITLE
Allow for cron pull from multiple channels.

### DIFF
--- a/modules/wri_spoke/src/Form/EntityShareCronSettingsForm.php
+++ b/modules/wri_spoke/src/Form/EntityShareCronSettingsForm.php
@@ -76,7 +76,7 @@ class EntityShareCronSettingsForm extends ConfigFormBase {
         'events_brasil' => $this->t('Events for WRI Brasil'),
         'events_brasil_pt_br' => $this->t('Events for WRI Brasil (Portuguese, Brazil)'),
         'events_china' => $this->t('Events for WRI China'),
-        'events_china_zh_hans' => $this->t('Events for WRI China (Chinese, Simplified'),
+        'events_china_zh_hans' => $this->t('Events for WRI China (Chinese, Simplified)'),
         'events_espanol' => $this->t('Events for WRI Espanol'),
         'events_espanol_es' => $this->t('Events for WRI Espanol (Spanish)'),
         'events_flagship' => $this->t('Events for WRI Flagship'),

--- a/modules/wri_spoke/src/Form/EntityShareCronSettingsForm.php
+++ b/modules/wri_spoke/src/Form/EntityShareCronSettingsForm.php
@@ -67,19 +67,25 @@ class EntityShareCronSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Remote'),
       '#default_value' => $settings['remote'] ?? '',
     ];
+    $channel_settings = is_array($settings['channel']) ? $settings['channel'] : [$settings['channel']];
     $form['channel'] = [
-      '#type' => 'select',
+      '#type' => 'checkboxes',
       '#options' => [
         'events_africa' => $this->t('Events for WRI Africa'),
+        'events_africa_fr' => $this->t('Events for WRI Africa (French)'),
         'events_brasil' => $this->t('Events for WRI Brasil'),
+        'events_brasil_pt_br' => $this->t('Events for WRI Brasil (Portuguese, Brazil)'),
         'events_china' => $this->t('Events for WRI China'),
+        'events_china_zh_hans' => $this->t('Events for WRI China (Chinese, Simplified'),
         'events_espanol' => $this->t('Events for WRI Espanol'),
+        'events_espanol_es' => $this->t('Events for WRI Espanol (Spanish)'),
         'events_flagship' => $this->t('Events for WRI Flagship'),
         'events_india' => $this->t('Events for WRI India'),
         'events_indonesia' => $this->t('Events for WRI Indonesia'),
+        'events_indonesia_id' => $this->t('Events for WRI Indonesia (Indonesian)'),
       ],
       '#title' => $this->t('Channel'),
-      '#default_value' => $settings['channel'] ?? '',
+      '#default_value' => $channel_settings,
     ];
     $form['limit'] = [
       '#type' => 'number',
@@ -87,11 +93,19 @@ class EntityShareCronSettingsForm extends ConfigFormBase {
       '#default_value' => $settings['limit'] ?? 20,
     ];
     $form['changed_since'] = [
-      '#type' => 'textfield',
-      '#title' => $this->t('Last synced change time'),
-      '#description' => $this->t('Do not edit this unless you know what you are doing. Setting it to 0 will cause event synchronization to go back to the oldest events on the Hub and work forward slowly.'),
-      '#default_value' => $settings['changed_since'] ?? 0,
+      '#type' => 'fieldset',
+      '#title' => $this->t('Last synced change times by channel'),
+      '#tree' => TRUE,
     ];
+    foreach ($settings['changed_since'] as $id => $value) {
+      $form['changed_since'][$id] = [
+        '#type' => 'textfield',
+        '#title' => $form['channel']['#options'][$id],
+        '#description' => $this->t('Do not edit this unless you know what you are doing. Setting it to 0 will cause event synchronization to go back to the oldest events on the Hub and work forward slowly.'),
+        '#default_value' => $value ?? 0,
+      ];
+
+    }
 
     return $form;
   }
@@ -106,6 +120,25 @@ class EntityShareCronSettingsForm extends ConfigFormBase {
     $config = $this->config(self::SETTINGS);
     foreach ($values as $key => $val) {
       $config->set($key, $val);
+    }
+    $changed_since = $config->get('changed_since');
+    if (!is_array($changed_since)) {
+      $changed_since = [
+        current($form["channel"]["#value"]) => $changed_since,
+      ];
+    }
+    $new_channels = FALSE;
+    foreach ($values["channel"] as $id => $selected) {
+      if ($selected && !isset($changed_since[$id])) {
+        $changed_since[$id] = 0;
+        $new_channels = TRUE;
+      }
+    }
+    if ($new_channels) {
+      unset($changed_since[0]);
+      unset($changed_since[1]);
+      unset($changed_since[2]);
+      $config->set('changed_since', $changed_since);
     }
     $config->save();
   }

--- a/modules/wri_spoke/wri_spoke.module
+++ b/modules/wri_spoke/wri_spoke.module
@@ -11,74 +11,83 @@ use Drupal\entity_share_client\Service\StateInformationInterface;
 
 /**
  * Implements hook_cron().
+ *
+ * @throws \DateMalformedStringException
  */
 function wri_spoke_cron() {
   $remote_manager = \Drupal::service('entity_share_client.remote_manager');
   $settings = \Drupal::service('config.factory')->getEditable('wri_spoke.cron.settings');
 
   $import_config_id = 'hub_events';
-  $channel_id = $settings->get('channel');
+  $channel_settings = $settings->get('channel');
+  if (!is_array($channel_settings)) {
+    $channel_settings = [$channel_settings];
+  }
   $remote_id = $settings->get('remote');
 
   $remote = \Drupal::entityTypeManager()->getStorage('remote')->load($remote_id);
   $channels_info = $remote_manager->getChannelsInfos($remote, [
     'rethrow' => TRUE,
   ]);
-  if (isset($channels_info[$channel_id])) {
-    $sync_from_time = $settings->get('changed_since') ?? 0;
-    if ($sync_from_time) {
-      $time = new DateTime($sync_from_time);
+  $sync_from_times = $settings->get('changed_since') ?? [];
+  foreach ($channel_settings as $channel_id) {
+    $channel_sync_from = $sync_from_times[$channel_id] ?: 0;
+    if ($channel_sync_from) {
+      $time = new DateTime($channel_sync_from);
       $filter_time = $time->getTimestamp();
     }
     else {
       $filter_time = 0;
     }
-    $parsed_url = UrlHelper::parse($channels_info[$channel_id]['url']);
-    $parsed_url['query']['filter'] = [
-      'changed' => [
-        'path' => 'changed',
-        'operator' => '>',
-        'value' => $filter_time,
-      ],
-    ];
-    $parsed_url['query']['sort'] = [
-      'changed' => [
-        'path' => 'changed',
-        'direction' => 'ASC',
-      ],
-    ];
-    $prepared_url = $parsed_url['path'] . '?' . UrlHelper::buildQuery($parsed_url['query']);
+    if (isset($channels_info[$channel_id])) {
+      $parsed_url = UrlHelper::parse($channels_info[$channel_id]['url']);
+      $parsed_url['query']['filter'] = [
+        'changed' => [
+          'path' => 'changed',
+          'operator' => '>',
+          'value' => $filter_time,
+        ],
+      ];
+      $parsed_url['query']['sort'] = [
+        'changed' => [
+          'path' => 'changed',
+          'direction' => 'ASC',
+        ],
+      ];
+      $prepared_url = $parsed_url['path'] . '?' . UrlHelper::buildQuery($parsed_url['query']);
 
-    try {
-      $response = $remote_manager->jsonApiRequest($remote, 'GET', $prepared_url, [
-        'rethrow' => TRUE,
-      ]);
-    }
-    catch (\Throwable $exception) {
-      \Drupal::logger('wri_spoke')->error('Unable to retrieve Events from the Hub.');
-      return;
-    }
-    $json = Json::decode((string) $response->getBody());
-    $data = array_slice($json['data'], 0, $settings->get('limit') ?? 20);
-
-    $state_information = \Drupal::service('entity_share_client.state_information');
-    $entities_to_sync = [];
-    $states_to_sync = [
-      StateInformationInterface::INFO_ID_NEW,
-      StateInformationInterface::INFO_ID_CHANGED,
-    ];
-    foreach ($data as $item) {
-      $sync_state = $state_information->getStatusInfo($item);
-      $sync_from_time = $item['attributes']['changed'];
-      if (in_array($sync_state['info_id'], $states_to_sync)) {
-        $entities_to_sync[] = $item['id'];
+      try {
+        $response = $remote_manager->jsonApiRequest($remote, 'GET', $prepared_url, [
+          'rethrow' => TRUE,
+        ]);
       }
+      catch (\Throwable $exception) {
+        \Drupal::logger('wri_spoke')
+          ->error("Unable to retrieve Events from the Hub for channel $channel_id.");
+        continue;
+      }
+      $json = Json::decode((string) $response->getBody());
+      $data = array_slice($json['data'], 0, $settings->get('limit') ?? 20);
+
+      $state_information = \Drupal::service('entity_share_client.state_information');
+      $entities_to_sync = [];
+      $states_to_sync = [
+        StateInformationInterface::INFO_ID_NEW,
+        StateInformationInterface::INFO_ID_CHANGED,
+      ];
+      foreach ($data as $item) {
+        $sync_state = $state_information->getStatusInfo($item);
+        $channel_sync_from = $item['attributes']['changed'];
+        if (in_array($sync_state['info_id'], $states_to_sync)) {
+          $entities_to_sync[] = $item['id'];
+        }
+      }
+      /** @var \Drupal\entity_share_async\Service\QueueHelperInterface $queue_helper */
+      $queue_helper = \Drupal::service('entity_share_async.queue_helper');
+      $queue_helper->enqueue($remote_id, $channel_id, $import_config_id, $entities_to_sync);
+      $sync_from_times[$channel_id] = $channel_sync_from;
     }
-    /** @var \Drupal\entity_share_async\Service\QueueHelperInterface $queue_helper */
-    $queue_helper = \Drupal::service('entity_share_async.queue_helper');
-    $queue_helper->enqueue($remote_id, $channel_id, $import_config_id, $entities_to_sync);
-    $settings->set('changed_since', $sync_from_time);
+    $settings->set('changed_since', $sync_from_times);
     $settings->save();
   }
-
 }

--- a/modules/wri_spoke/wri_spoke.module
+++ b/modules/wri_spoke/wri_spoke.module
@@ -30,62 +30,64 @@ function wri_spoke_cron() {
     'rethrow' => TRUE,
   ]);
   $sync_from_times = $settings->get('changed_since') ?? [];
-  foreach ($channel_settings as $channel_id) {
-    $channel_sync_from = $sync_from_times[$channel_id] ?: 0;
-    if ($channel_sync_from) {
-      $time = new DateTime($channel_sync_from);
-      $filter_time = $time->getTimestamp();
-    }
-    else {
-      $filter_time = 0;
-    }
-    if (isset($channels_info[$channel_id])) {
-      $parsed_url = UrlHelper::parse($channels_info[$channel_id]['url']);
-      $parsed_url['query']['filter'] = [
-        'changed' => [
-          'path' => 'changed',
-          'operator' => '>',
-          'value' => $filter_time,
-        ],
-      ];
-      $parsed_url['query']['sort'] = [
-        'changed' => [
-          'path' => 'changed',
-          'direction' => 'ASC',
-        ],
-      ];
-      $prepared_url = $parsed_url['path'] . '?' . UrlHelper::buildQuery($parsed_url['query']);
-
-      try {
-        $response = $remote_manager->jsonApiRequest($remote, 'GET', $prepared_url, [
-          'rethrow' => TRUE,
-        ]);
+  foreach ($channel_settings as $channel_id => $enabled) {
+    if ($enabled) {
+      $channel_sync_from = $sync_from_times[$channel_id] ?? 0;
+      if ($channel_sync_from) {
+        $time = new DateTime($channel_sync_from);
+        $filter_time = $time->getTimestamp();
       }
-      catch (\Throwable $exception) {
-        \Drupal::logger('wri_spoke')
-          ->error("Unable to retrieve Events from the Hub for channel $channel_id.");
-        continue;
+      else {
+        $filter_time = 0;
       }
-      $json = Json::decode((string) $response->getBody());
-      $data = array_slice($json['data'], 0, $settings->get('limit') ?? 20);
+      if (isset($channels_info[$channel_id])) {
+        $parsed_url = UrlHelper::parse($channels_info[$channel_id]['url']);
+        $parsed_url['query']['filter'] = [
+          'changed' => [
+            'path' => 'changed',
+            'operator' => '>',
+            'value' => $filter_time,
+          ],
+        ];
+        $parsed_url['query']['sort'] = [
+          'changed' => [
+            'path' => 'changed',
+            'direction' => 'ASC',
+          ],
+        ];
+        $prepared_url = $parsed_url['path'] . '?' . UrlHelper::buildQuery($parsed_url['query']);
 
-      $state_information = \Drupal::service('entity_share_client.state_information');
-      $entities_to_sync = [];
-      $states_to_sync = [
-        StateInformationInterface::INFO_ID_NEW,
-        StateInformationInterface::INFO_ID_CHANGED,
-      ];
-      foreach ($data as $item) {
-        $sync_state = $state_information->getStatusInfo($item);
-        $channel_sync_from = $item['attributes']['changed'];
-        if (in_array($sync_state['info_id'], $states_to_sync)) {
-          $entities_to_sync[] = $item['id'];
+        try {
+          $response = $remote_manager->jsonApiRequest($remote, 'GET', $prepared_url, [
+            'rethrow' => TRUE,
+          ]);
         }
+        catch (\Throwable $exception) {
+          \Drupal::logger('wri_spoke')
+            ->error("Unable to retrieve Events from the Hub for channel $channel_id.");
+          continue;
+        }
+        $json = Json::decode((string) $response->getBody());
+        $data = array_slice($json['data'], 0, $settings->get('limit') ?? 20);
+
+        $state_information = \Drupal::service('entity_share_client.state_information');
+        $entities_to_sync = [];
+        $states_to_sync = [
+          StateInformationInterface::INFO_ID_NEW,
+          StateInformationInterface::INFO_ID_CHANGED,
+        ];
+        foreach ($data as $item) {
+          $sync_state = $state_information->getStatusInfo($item);
+          $channel_sync_from = $item['attributes']['changed'];
+          if (in_array($sync_state['info_id'], $states_to_sync)) {
+            $entities_to_sync[] = $item['id'];
+          }
+        }
+        /** @var \Drupal\entity_share_async\Service\QueueHelperInterface $queue_helper */
+        $queue_helper = \Drupal::service('entity_share_async.queue_helper');
+        $queue_helper->enqueue($remote_id, $channel_id, $import_config_id, $entities_to_sync);
+        $sync_from_times[$channel_id] = $channel_sync_from;
       }
-      /** @var \Drupal\entity_share_async\Service\QueueHelperInterface $queue_helper */
-      $queue_helper = \Drupal::service('entity_share_async.queue_helper');
-      $queue_helper->enqueue($remote_id, $channel_id, $import_config_id, $entities_to_sync);
-      $sync_from_times[$channel_id] = $channel_sync_from;
     }
     $settings->set('changed_since', $sync_from_times);
     $settings->save();


### PR DESCRIPTION
You have to have separate channels for different languages.

This adds all the language option machine names that will need to be manually created on the hub with matching machine names. It also allows for multiple channels to be synced via cron.

#536