### PR TITLE
Use translated content for hub links. 

### DIFF
--- a/modules/wri_spoke/src/Path/SpokeHostProcessor.php
+++ b/modules/wri_spoke/src/Path/SpokeHostProcessor.php
@@ -65,10 +65,16 @@ class SpokeHostProcessor implements OutboundPathProcessorInterface {
     if (!($node instanceof Node)) {
       return $path;
     }
+    if (isset($options['language'])) {
+      $node = $node->getTranslation($options['language']->getId());
+    }
     if ($node->bundle() == 'event' && $node->field_hub_canonical_url->value) {
       $options['absolute'] = TRUE;
       $hub_url = parse_url($node->field_hub_canonical_url->value);
       $options['base_url'] = $hub_url['scheme'] . "://" . $hub_url['host'];
+      // The prefix is used to add a translation code, but in this case we don't
+      // need it added: it's already there if it's translated content.
+      unset($options["prefix"]);
       if ($request) {
         $options['query']['returnTo'] = $request->getScheme() . "://" . $request->getHttpHost() . $request->getRequestUri();
       }

--- a/modules/wri_spoke/wri_spoke.services.yml
+++ b/modules/wri_spoke/wri_spoke.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\wri_spoke\Path\SpokeHostProcessor
     arguments: ['@entity_type.manager']
     tags:
-      - { name: path_processor_outbound, priority: 3000 }
+      - { name: path_processor_outbound, priority: -10 }


### PR DESCRIPTION
#536

Our existing hub link rewrite didn't take translation into account. This fixes that. However, it's a little hacky.

It's possible we should refactor this and let translation do its prefix thing for us. Instead, we would change the logic that populates the `field_hub_canonical_url` value on the hub to leave the translation prefix off. That's a little strange because it stops being canonical.

I went with this approach because if some other code in the future adds additional things to the "prefix", we actually would probably _not_ want them added either, since we just want the exact URL in the field.