### PR TITLE
WRIN 537: make side-by-side paragraph theme global

### DIFF
--- a/themes/custom/ts_wrin/sass/components/_simple-page.scss
+++ b/themes/custom/ts_wrin/sass/components/_simple-page.scss
@@ -65,87 +65,6 @@
     }
   }
 
-  .paragraph--type--side-by-side {
-    @extend .grid;
-    @extend .margin-top-xl;
-    @extend .margin-bottom-xl;
-    position: relative;
-
-    &:before {
-      content: "";
-      @extend .top-border-thick;
-      display: block;
-      @include column-width(1, -1);
-      margin: $space-xs 0 0;
-      padding-top: $space-xs;
-      grid-row: 1;
-
-      @include mq($md) {
-        @include column-width(2, 6);
-      }
-    }
-
-    .field--name-field-title {
-      @include column-width(1, -1);
-      grid-row: 2;
-      margin-top: 0;
-
-      @include mq($md) {
-        @include column-width(2, 6);
-        grid-row: 1;
-        margin-top: $space-md;
-      }
-
-      h2 {
-        @include font($acumin-semi-cond, bold);
-        @include font-line-height(32, 40);
-        margin: 0;
-      }
-    }
-
-    .field--name-field-body {
-      @include column-width(1, -1);
-      grid-row: 3;
-
-      @include mq($md) {
-        @include column-width(6, 12);
-        grid-row: 1;
-      }
-
-      p {
-        @include font($acumin-semi-cond, light);
-        @include font-line-height(18, 30);
-
-        &:first-of-type {
-          @include mq($md) {
-            margin-top: 10px;
-          }
-        }
-      }
-    }
-    .media--view-mode-half-content {
-      width: 50%;
-    }
-    .media--view-mode-full,
-    .media--view-mode-full-width {
-      @include mq($md) {
-        margin: 0;
-        left: 0;
-        right: 0;
-        width: 100%;
-      }
-    }
-
-    a {
-      background-position: left 100%;
-    }
-
-    img {
-      width: 100%;
-      height: auto;
-    }
-  }
-
   .paragraph--type--statistics {
     .field--name-field-statistics {
       @include mq($md) {
@@ -188,6 +107,87 @@
     @include mq($md) {
       display: block;
     }
+  }
+}
+
+.paragraph--type--side-by-side {
+  @extend .grid;
+  @extend .margin-top-xl;
+  @extend .margin-bottom-xl;
+  position: relative;
+
+  &:before {
+    content: "";
+    @extend .top-border-thick;
+    display: block;
+    @include column-width(1, -1);
+    margin: $space-xs 0 0;
+    padding-top: $space-xs;
+    grid-row: 1;
+
+    @include mq($md) {
+      @include column-width(2, 6);
+    }
+  }
+
+  .field--name-field-title {
+    @include column-width(1, -1);
+    grid-row: 2;
+    margin-top: 0;
+
+    @include mq($md) {
+      @include column-width(2, 6);
+      grid-row: 1;
+      margin-top: $space-md;
+    }
+
+    h2 {
+      @include font($acumin-semi-cond, bold);
+      @include font-line-height(32, 40);
+      margin: 0;
+    }
+  }
+
+  .field--name-field-body {
+    @include column-width(1, -1);
+    grid-row: 3;
+
+    @include mq($md) {
+      @include column-width(6, 12);
+      grid-row: 1;
+    }
+
+    p {
+      @include font($acumin-semi-cond, light);
+      @include font-line-height(18, 30);
+
+      &:first-of-type {
+        @include mq($md) {
+          margin-top: 10px;
+        }
+      }
+    }
+  }
+  .media--view-mode-half-content {
+    width: 50%;
+  }
+  .media--view-mode-full,
+  .media--view-mode-full-width {
+    @include mq($md) {
+      margin: 0;
+      left: 0;
+      right: 0;
+      width: 100%;
+    }
+  }
+
+  a {
+    background-position: left 100%;
+  }
+
+  img {
+    width: 100%;
+    height: auto;
   }
 }
 


### PR DESCRIPTION
## What issue(s) does this solve?
 - Side-by-side paragraph theming only applies on simple-page type. 

- [x] Issue Number: https://github.com/wri/WRIN/issues/537

## What is the new behavior?
 - Side-by-side paragraph theming applies on all content types

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [x] Flagship PR: https://github.com/wri/wriflagship/pull/1377

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
