### PR TITLE
WRI_SITES 534: fix cached returnTo URL var

### DIFF
--- a/modules/wri_spoke/js/wri-spoke-return-to.js
+++ b/modules/wri_spoke/js/wri-spoke-return-to.js
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * Populate the `returnTo` query param on hub links at runtime.
+ *
+ * We intentionally leave `returnTo` empty in PHP to avoid cached/stale values.
+ */
+
+(function (Drupal, once) {
+  Drupal.behaviors.wriSpokeReturnTo = {
+    attach(context) {
+      // Full URL of the current page, without the hash.
+      const currentUrl = window.location.origin + window.location.pathname + window.location.search;
+
+      once("wri-spoke-return-to", 'a[href*="returnTo"]', context).forEach((link) => {
+        const href = link.getAttribute("href");
+        if (!href) return;
+
+        let url;
+        try {
+          // Support relative and absolute URLs.
+          url = new URL(href, window.location.origin);
+        } catch (e) {
+          return;
+        }
+
+        // Only update links that already have `returnTo` in the query string.
+        if (!url.searchParams.has("returnTo")) return;
+
+        url.searchParams.set("returnTo", currentUrl);
+
+        // Preserve relative URLs if the original was relative.
+        const isAbsolute = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(href);
+        link.setAttribute("href", isAbsolute ? url.toString() : url.pathname + url.search + url.hash);
+      });
+    },
+  };
+})(Drupal, once);

--- a/modules/wri_spoke/src/Path/SpokeHostProcessor.php
+++ b/modules/wri_spoke/src/Path/SpokeHostProcessor.php
@@ -105,8 +105,9 @@ class SpokeHostProcessor implements OutboundPathProcessorInterface {
       // The prefix is used to add a translation code, but in this case we don't
       // need it added: we have our full URL coming from the hub url field.
       unset($options["prefix"]);
-      if ($request && !$this->adminContext->isAdminRoute()) {
-        $options['query']['returnTo'] = $request->getScheme() . "://" . $request->getHttpHost() . $request->getRequestUri();
+      // Always add returnTo, but leave it empty so JS can set it per page.
+      if (!$this->adminContext->isAdminRoute()) {
+        $options['query']['returnTo'] = '';
       }
       $path = $hub_url['path'];
     }

--- a/modules/wri_spoke/wri_spoke.libraries.yml
+++ b/modules/wri_spoke/wri_spoke.libraries.yml
@@ -1,0 +1,7 @@
+return_to:
+  version: 1.x
+  js:
+    js/wri-spoke-return-to.js: {}
+  dependencies:
+    - core/drupal
+    - core/once

--- a/modules/wri_spoke/wri_spoke.module
+++ b/modules/wri_spoke/wri_spoke.module
@@ -93,3 +93,16 @@ function wri_spoke_cron() {
     $settings->save();
   }
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function wri_spoke_page_attachments(array &$attachments): void {
+  /** @var \Drupal\Core\Routing\AdminContext $admin_context */
+  $admin_context = \Drupal::service('router.admin_context');
+  if ($admin_context->isAdminRoute()) {
+    return;
+  }
+
+  $attachments['#attached']['library'][] = 'wri_spoke/return_to';
+}


### PR DESCRIPTION
## What issue(s) does this solve?
ReturnTo URLs are cached.

- [ ] Issue Number: https://github.com/wri/wri_sites/issues/534

## What is the new behavior?
- ReturnTo URLs are NOT cached.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR: https://github.com/wri/wriflagship/pull/1384

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
