### PR TITLE
Moving some variables out of the twig template.

### DIFF
--- a/modules/wri_article/templates/wri-article-columns-b.html.twig
+++ b/modules/wri_article/templates/wri-article-columns-b.html.twig
@@ -18,24 +18,6 @@
     {% endif %}
   {% endif %}
 
-  {% set template_class = null %}
-  {% if node and node.hasField('field_type') and not node.get('field_type').isEmpty() %}
-    {% set type = node.get('field_type').entity %}
-    {% set parent = type and not type.get('parent').isEmpty() ? type.get('parent').entity : null %}
-    {% set parent_label = parent ? parent.label : null %}
-
-    {% set map = {
-      'Technical Perspectives': 'technical-perspective-template',
-      'Update': 'project-update-template',
-      'News': 'news-template',
-      'Top Outcome': 'project-update-template',
-      '2025 Top Outcome': 'project-update-template',
-      'Snapshot': 'project-update-template'
-    } %}
-
-    {% set template_class = map[parent_label] ?? null %}
-  {% endif %}
-
   {% if node and node.hasField('field_hide_featured_wri_experts') and node.get('field_hide_featured_wri_experts').value == 1 %}
     {% set hide_featured_experts = true %}
   {% endif %}
@@ -61,7 +43,7 @@
     {% if content.title|render %}
       <div {{ region_attributes.title.addClass('layout__region', 'layout__region--full', 'title-wrapper', 'full-width', region_display_value) }}>
         {% if template_class %}
-          <div class="utility-base btn-pill font-bold">{{ type.label }}</div>
+          <div class="utility-base btn-pill font-bold">{{ type_label }}</div>
           {{ content.title|without('field_type') }}
         {% else %}
           {{ content.title }}

--- a/modules/wri_article/wri_article.module
+++ b/modules/wri_article/wri_article.module
@@ -47,6 +47,27 @@ function wri_article_preprocess_wri_article_columns_b(array &$variables): void {
     return;
   }
 
+  $variables['template_class'] = '';
+  $variables['type_label'] = '';
+  if ($node->hasField('field_type') && !$node->get('field_main_image')->isEmpty()) {
+    $type = $node->get('field_type')->entity;
+    $variables['type_label'] = $type->getName();
+    $parent = $type->get('parent')->entity;
+    $parent_label = $parent ? $parent->getName() : null;
+
+    $map = [
+      'Technical Perspectives' => 'technical-perspective-template',
+      'Update'=> 'project-update-template',
+      'News'=> 'news-template',
+      'Top Outcome'=> 'project-update-template',
+      '2025 Top Outcome'=> 'project-update-template',
+      'Snapshot'=> 'project-update-template'
+    ];
+
+    $variables['template_class'] = $map[$parent_label] ?? null;
+  }
+
+
   if (!$node->hasField('field_main_image') || $node->get('field_main_image')->isEmpty()) {
     return;
   }

--- a/modules/wri_article/wri_article.module
+++ b/modules/wri_article/wri_article.module
@@ -53,20 +53,19 @@ function wri_article_preprocess_wri_article_columns_b(array &$variables): void {
     $type = $node->get('field_type')->entity;
     $variables['type_label'] = $type->getName();
     $parent = $type->get('parent')->entity;
-    $parent_label = $parent ? $parent->getName() : null;
+    $parent_label = $parent ? $parent->getName() : NULL;
 
     $map = [
       'Technical Perspectives' => 'technical-perspective-template',
-      'Update'=> 'project-update-template',
-      'News'=> 'news-template',
-      'Top Outcome'=> 'project-update-template',
-      '2025 Top Outcome'=> 'project-update-template',
-      'Snapshot'=> 'project-update-template'
+      'Update' => 'project-update-template',
+      'News' => 'news-template',
+      'Top Outcome' => 'project-update-template',
+      '2025 Top Outcome' => 'project-update-template',
+      'Snapshot' => 'project-update-template',
     ];
 
-    $variables['template_class'] = $map[$parent_label] ?? null;
+    $variables['template_class'] = $map[$parent_label] ?? NULL;
   }
-
 
   if (!$node->hasField('field_main_image') || $node->get('field_main_image')->isEmpty()) {
     return;


### PR DESCRIPTION
## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: https://github.com/wri/wriflagship/issues/1425

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Moves logic for the template type out of the twig template and into the module file, where an undefined element is likely to be handled more gracefully.

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [x] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
