### PR TITLE
Replace nav/breadcrumb block-title h2 with div

### DIFF
--- a/themes/custom/ts_wrin/templates/blocks/block--menu-block--microsites-level-2.html.twig
+++ b/themes/custom/ts_wrin/templates/blocks/block--menu-block--microsites-level-2.html.twig
@@ -22,7 +22,7 @@
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  <div{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</div>
   {{ title_suffix }}
 
   {# Menu. #}

--- a/themes/custom/ts_wrin/templates/menus/block--quicklinks.html.twig
+++ b/themes/custom/ts_wrin/templates/menus/block--quicklinks.html.twig
@@ -21,7 +21,7 @@
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  <div{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</div>
   {{ title_suffix }}
 
   {# Menu. #}

--- a/themes/custom/ts_wrin/templates/menus/block--ts-wrin-main-menu.html.twig
+++ b/themes/custom/ts_wrin/templates/menus/block--ts-wrin-main-menu.html.twig
@@ -19,7 +19,7 @@
     {% set title_attributes = title_attributes.addClass('visually-hidden') %}
   {% endif %}
   {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  <div{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</div>
   {{ title_suffix }}
 
   {# Menu. #}

--- a/themes/custom/ts_wrin/templates/navigation/breadcrumb.html.twig
+++ b/themes/custom/ts_wrin/templates/navigation/breadcrumb.html.twig
@@ -9,7 +9,7 @@
 #}
 {% if breadcrumb and breadcrumb.1 %}
   <nav class="breadcrumb" role="navigation" aria-labelledby="system-breadcrumb">
-    <h2 id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</h2>
+    <div id="system-breadcrumb" class="visually-hidden">{{ 'Breadcrumb'|t }}</div>
     <ol>
     {% for item in breadcrumb %}
       {% if loop.last and not loop.first %}


### PR DESCRIPTION
The h2 wrapping each nav block's title (main menu, quicklinks, microsites sub-nav, breadcrumb) only labels its parent nav via aria-labelledby and is usually visually hidden, but it still injects non-content headings into the page's heading outline. Using a div instead preserves the existing aria-labelledby relationship and visual-hidden behavior without the heading-hierarchy issue.

## What issue(s) does this solve?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- [ ] Issue Number: #WRIN/TODO

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Profile requirements:

- Does deploying this change require a change to config at the site level (choose one)?
  - [ ] No config change is required.
  - [ ] Yes, and I have written an update hook to apply these config changes.
  - [ ] Yes, and I've included updating instructions to be added to the release notes. The next release will need to be a major version increase. (Only do this in special cases.)

## Site-level pull requests for testing. Only merge when these PRs are approved:

<!-- List any open pull requests where a reviewer might check code -->
Create or update any site-level pull requests following [the documentation](https://github.com/wri/WRIN/wiki/WRI-Dev-Workflow-(Thinkshout)#generating-a-multidev-for-wri_sites-work-review)

- [ ] Flagship PR:

## Checked on develop (TA to do)
<!-- a TA will pull the latest release to develop after this PR is merged, then do the update hooks and config import needed to apply this code to the site. -->
- [ ] Brasil
- [ ] China
- [ ] Indonesia
